### PR TITLE
fix ipify url

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -12,7 +12,7 @@ with open(PATH + "config.json") as config_file:
 
 def getIPs():
     a = requests.get("https://dns.timknowsbest.com/api/ipv4").text
-    aaaa = requests.get("https://api6.ipify.org?format=json").json().get("ip")
+    aaaa = requests.get("https://api64.ipify.org?format=json").json().get("ip")
     ips = []
 
     if(a.find(".") > -1):


### PR DESCRIPTION
api6.apify url is no longer returning anything causing a nasty traceback. This fixes that issue by utilizing the api64.ipify url which appears to return the same result that api6 used to return.