### PR TITLE
Fix indents in config-example.json

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -2,11 +2,11 @@
   "cloudflare": [
     {
       "authentication": {
-          "api_token": "api_token_here", 
-          "api_key": {
-              "api_key": "api_key_here",
-              "account_email": "your_email_here"
-	        }
+        "api_token": "api_token_here", 
+        "api_key": {
+          "api_key": "api_key_here",
+          "account_email": "your_email_here"
+        }
       },
       "zone_id": "your_zone_id_here",
       "subdomains": [


### PR DESCRIPTION
- Replaced a tab character with spaces.
- Normalized indents by 2 spaces.
