### PR TITLE
File/environment-based secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This script was written for the Raspberry Pi platform to enable low cost, simple
 
 ## 📊 Stats
 
-| Size  | Downloads | Discord |
-| ------------- | ------------- | ------------- |
-| [![cloudflare-ddns docker image size](https://img.shields.io/docker/image-size/timothyjmiller/cloudflare-ddns?style=flat-square)](https://hub.docker.com/r/timothyjmiller/cloudflare-ddns "cloudflare-ddns docker image size")  | [![Total DockerHub pulls](https://img.shields.io/docker/pulls/timothyjmiller/cloudflare-ddns?style=flat-square)](https://hub.docker.com/r/timothyjmiller/cloudflare-ddns "Total DockerHub pulls")  | [![Official Discord Server](https://img.shields.io/discord/785778163887112192?style=flat-square)](https://discord.gg/UgGmwMvNxm "Official Discord Server")
+| Size                                                                                                                                                                                                                           | Downloads                                                                                                                                                                                         | Discord                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [![cloudflare-ddns docker image size](https://img.shields.io/docker/image-size/timothyjmiller/cloudflare-ddns?style=flat-square)](https://hub.docker.com/r/timothyjmiller/cloudflare-ddns "cloudflare-ddns docker image size") | [![Total DockerHub pulls](https://img.shields.io/docker/pulls/timothyjmiller/cloudflare-ddns?style=flat-square)](https://hub.docker.com/r/timothyjmiller/cloudflare-ddns "Total DockerHub pulls") | [![Official Discord Server](https://img.shields.io/discord/785778163887112192?style=flat-square)](https://discord.gg/UgGmwMvNxm "Official Discord Server") |
 
 ## ⁉️ How Private & Secure?
 
@@ -63,9 +63,28 @@ Alternatively, you can use the traditional API keys by setting appropriate value
 "proxied": false (defaults to false. Make it true if you want CDN/SSL benefits from cloudflare. This usually disables SSH)
 ```
 
+### Value Substitution
+
+Some configuration values can also be provided indirectly by instructing Cloudflare DDNS to read them from environment variables or files, rather than directly from `config.json`. To do this, replace the value with an nested object containing the key `file` or `env` where the value is the file/environment variable to read from. For example:
+
+```json
+"authentication":
+  "api_token":
+    "file": "/path/to/your/file"
+"zone_id":
+  "env": "ENV_VAR_NAME"
+```
+
+This substitution works for the following configuration values:
+
+- `authentication.api_token`
+- `authentication.api_key.api_key`
+- `authentication.api_key.account_email`
+- `zone_id`
+
 ## 📠 Hosting multiple domains on the same IP?
 
-You can save yourself some trouble when hosting multiple domains pointing to the same IP address (in the case of Traefik) by defining one A & AAAA record  'ddns.example.com' pointing to the IP of the server that will be updated by this DDNS script. For each subdomain, create a CNAME record pointing to 'ddns.example.com'. Now you don't have to manually modify the script config every time you add a new subdomain to your site!
+You can save yourself some trouble when hosting multiple domains pointing to the same IP address (in the case of Traefik) by defining one A & AAAA record 'ddns.example.com' pointing to the IP of the server that will be updated by this DDNS script. For each subdomain, create a CNAME record pointing to 'ddns.example.com'. Now you don't have to manually modify the script config every time you add a new subdomain to your site!
 
 ## 🐳 Deploy with Docker Compose
 
@@ -114,9 +133,9 @@ Docker Hub has experimental support for multi-architecture builds. Their officia
 
 1. Choose build platform
 
-- Multi-architecture (experimental)  `docker-build-all.sh`
+- Multi-architecture (experimental) `docker-build-all.sh`
 
-- Linux/amd64 by default  `docker-build.sh`
+- Linux/amd64 by default `docker-build.sh`
 
 2. Give your bash script permission to execute.
 

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -42,13 +42,13 @@ secret_configs = [
 for c in config['cloudflare']:
     for sc in secret_configs:
         sc_file = sc + ["file"]
-        if (nestedGet(c, sc_file) != None):
+        if(nestedGet(c, sc_file) != None):
             print('Reading config value for ' + str(sc) + ' from file')
             value = open(nestedGet(c, sc_file), "r").read().strip()
             nestedSet(c, sc, value)
 
         sc_env = sc + ["env"]
-        if (nestedGet(c, sc_env) != None):
+        if(nestedGet(c, sc_env) != None):
             print('Reading config value for ' + str(sc) + ' from env')
             value = os.environ[nestedGet(c, sc_env)]
             nestedSet(c, sc, value)


### PR DESCRIPTION
Fixes #31

First draft of a way to provide some config values from a file or environment variable rather than hardcoding them in `config.json` that is fully backwards compatible. It works by replacing the constant values with nested objects as follows:

```json
"authentication": {
  "api_token": "my_secret_value"
}

// becomes...

"authentication": {
  "api_token": {
    "file": "/path/to/my/secret/file"
  }
}

// or...

"authentication": {
  "api_token": {
    "env": "MY_SECRET_ENV_VAR_NAME"
  }
}
```

I went with replacing the values rather than adding new keys like `api_token_file` because a) it lead to cleaner code and b) it avoids the problem of "what if a user enters both?".

Right now this is implemented for the different auth configs and the zone ID - I think those make the most sense but happy to take feedback. I've added some brief docs in the readme but I could also add example docker-compose files or similar.