### PR TITLE
🦢 Log the response text, in case the response indicated an error

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -150,7 +150,8 @@ def cf_api(endpoint, method, config, headers={}, data=False):
     if response.ok:
         return response.json()
     else:
-        print("📈 Rate limit exceeded")
+        print("📈 Error sending '" + method + "' request to '" + response.url + "':")
+        print(response.text)
         return None
 
 def updateIPs(ips):


### PR DESCRIPTION
First of all, great little tool!

When I first started the Docker container, I continually got the error message "📈 Rate limit exceeded" in the logs.
But it turned out that the actual error was something different: my `config.json` was not correct, I used the domain name instead of the zone ID, so the cloudflare API gave the following response:
```
{"success":false,"errors":[{"code":7003,"message":"Could not route to \/zones\/mydomain.com, perhaps your object identifier is invalid?"},{"code":7000,"message":"No route for that URI"}],"messages":[],"result":null}
``` 

Additionally, I also set `proxied=true` on a wildcard `A record`, something that is not allowed on free Cloudflare accounts, which gave the response:
```
{"result":null,"success":false,"errors":[{"code":9004,"message":"This record type cannot be proxied."}],"messages":[]}
```

Unfortunately, both these responses were not printed in the logs, so it took me longer than needed to figure out why it wasn't working.

In this pull request, I propose to always just log the whole response (and what the request was) in case of an error, as that makes it a lot easier to complete the initial setup.

Note: I am aware that more logging is a potential security risk, but I am assuming here that Cloudflare won't return sensitive data as part of the response.