### PR TITLE
Config option for purge/delete of "stale" records

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -33,6 +33,7 @@ def getIPs():
     aaaa = None
     global ipv4_enabled
     global ipv6_enabled
+    global purgeUnknownRecords
     if ipv4_enabled:
         try:
             a = requests.get("https://1.1.1.1/cdn-cgi/trace").text.split("\n")
@@ -43,7 +44,8 @@ def getIPs():
             if not shown_ipv4_warning:
                 shown_ipv4_warning = True
                 print("🧩 IPv4 not detected")
-            deleteEntries("A")
+            if purgeUnknownRecords:
+                deleteEntries("A")
     if ipv6_enabled:
         try:
             aaaa = requests.get("https://[2606:4700:4700::1111]/cdn-cgi/trace").text.split("\n")
@@ -54,7 +56,8 @@ def getIPs():
             if not shown_ipv6_warning:
                 shown_ipv6_warning = True
                 print("🧩 IPv6 not detected")
-            deleteEntries("AAAA")
+            if purgeUnknownRecords:
+                deleteEntries("AAAA")
     ips = {}
     if(a is not None):
         ips["ipv4"] = {
@@ -118,12 +121,13 @@ def commitRecord(ip):
                 print("➕ Adding new record " + str(record))
                 response = cf_api(
                     "zones/" + option['zone_id'] + "/dns_records", "POST", option, {}, record)
-            for identifier in duplicate_ids:
-                identifier = str(identifier)
-                print("🗑️ Deleting stale record " + identifier)
-                response = cf_api(
-                    "zones/" + option['zone_id'] + "/dns_records/" + identifier,
-                    "DELETE", option)
+            if purgeUnknownRecords:
+                for identifier in duplicate_ids:
+                    identifier = str(identifier)
+                    print("🗑️ Deleting stale record " + identifier)
+                    response = cf_api(
+                        "zones/" + option['zone_id'] + "/dns_records/" + identifier,
+                        "DELETE", option)
     return True
 
 def cf_api(endpoint, method, config, headers={}, data=False):
@@ -165,6 +169,7 @@ if __name__ == '__main__':
     shown_ipv6_warning = False
     ipv4_enabled = True
     ipv6_enabled = True
+    purgeUnknownRecords = False
 
     if(version < 3.5):
         raise Exception("🐍 This script requires Python 3.5+")
@@ -185,6 +190,11 @@ if __name__ == '__main__':
             ipv4_enabled = True
             ipv6_enabled = True
             print("⚙️ Individually disable IPv4 or IPv6 with new config.json options. Read more about it here: https://github.com/timothymiller/cloudflare-ddns/blob/master/README.md")
+        try:
+            purgeUnknownRecords = config["purgeUnknownRecords"]
+        except:
+            purgeUnknownRecords = False
+            print("⚙️ No config detected for 'purgeUnknownRecords' - defaulting to False")
         if(len(sys.argv) > 1):
             if(sys.argv[1] == "--repeat"):
                 delay = 5*60

--- a/config-example.json
+++ b/config-example.json
@@ -1,4 +1,5 @@
 {
+  "purgeUnknownRecords": false,
   "cloudflare": [
     {
       "authentication": {


### PR DESCRIPTION
This change adds a config setting to control whether "stale" records are purged/deleted or not.  Checks were put in place both in commitRecord(ip) to control whether duplicates are deleted (unsure how that case arises, but wanted to provide the option to not delete if someone didn't want to) as well as deleteEntries(type), which was pulling any A or AAAA record not listed in config.json file.  People may be manually creating other A or AAAA records for purposes other than DDNS, and removing them automatically when trying to update DDNS records seems like an unintended action.  For that reason, the config option is listed as "purgeUnknownRecords" as it will purge anything not listed in the config.json file.  However, listing other A or AAAA records in the config.json will have them updated with the local IP to satisfy a DDNS update, so be careful listing anything you wouldn't want to change.

This pull request is intended to fix https://github.com/timothymiller/cloudflare-ddns/issues/47