### PR TITLE
Update GHA CI to use offical docker build/push actions and allow PR's to be tested 

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -3,6 +3,7 @@ name: Build cloudflare-ddns Docker image (multi-arch)
 on:
   push:
     branches: master
+  pull_request:
 
 jobs:
   build:
@@ -17,9 +18,37 @@ jobs:
       - name: Setting up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-      - name: Build & Publish to DockerHub
-        run: |
-          docker buildx build \
-            --tag timothyjmiller/cloudflare-ddns:latest \
-            --platform linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64 . --push
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: timothyjmiller/cloudflare-ddns
+          sep-tags: ','
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,enable=${{ steps.extract_branch.outputs.branch == 'master' }},value=latest
+            type=schedule
+            type=ref,event=pr
+            
+      - name: Build and publish
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
Update to use the offically supported docker GHA modules for building and tagging docker images.