### PR TITLE
Fixes Python version check

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -181,14 +181,14 @@ def updateIPs(ips):
         commitRecord(ip)
 
 if __name__ == '__main__':
-    version = float(str(sys.version_info[0]) + "." + str(sys.version_info[1]))
+    version = int(str(sys.version_info[0]) + str(sys.version_info[1]))
     shown_ipv4_warning = False
     shown_ipv6_warning = False
     ipv4_enabled = True
     ipv6_enabled = True
     purgeUnknownRecords = False
 
-    if(version < 3.5):
+    if(version < 35):
         raise Exception("🐍 This script requires Python 3.5+")
 
     config = None


### PR DESCRIPTION
This fixes the Python version check.

Casting to `float()` cuts trailing zeroes, so comparing a semver using floats breaks the expected behavior.

https://github.com/timothymiller/cloudflare-ddns/blob/2a4d9530dd3d47a65124c25b32a318e856d0598a/cloudflare-ddns.py#L184


```python
import sys

>>> sys.version_info
sys.version_info(major=3, minor=10, micro=0, releaselevel='final', serial=0)

version = float(str(sys.version_info[0]) + "." + str(sys.version_info[1]))

>>> version
3.1 # This should be 3.10. Without the fix, the script thinks that 3.10 is lower than 3.5
```