### PR TITLE
Add exception handling for api call

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -32,7 +32,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: timothyjmiller/cloudflare-ddns
+          images: hareeshmu/cloudflare-ddns
           sep-tags: ','
           flavor: |
             latest=false

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,5 +1,5 @@
 name: Build cloudflare-ddns Docker image (multi-arch)
-
+# update docker hub details
 on:
   push:
     branches: master

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -160,21 +160,25 @@ def cf_api(endpoint, method, config, headers={}, data=False):
             "X-Auth-Email": config['authentication']['api_key']['account_email'],
             "X-Auth-Key": config['authentication']['api_key']['api_key'],
         }
+    try:
+        if(data == False):
+            response = requests.request(
+                method, "https://api.cloudflare.com/client/v4/" + endpoint, headers=headers)
+        else:
+            response = requests.request(
+                method, "https://api.cloudflare.com/client/v4/" + endpoint,
+                headers=headers, json=data)
 
-    if(data == False):
-        response = requests.request(
-            method, "https://api.cloudflare.com/client/v4/" + endpoint, headers=headers)
-    else:
-        response = requests.request(
-            method, "https://api.cloudflare.com/client/v4/" + endpoint,
-            headers=headers, json=data)
-
-    if response.ok:
-        return response.json()
-    else:
-        print("📈 Error sending '" + method + "' request to '" + response.url + "':")
-        print(response.text)
+        if response.ok:
+            return response.json()
+        else:
+            print("😡 Error sending '" + method + "' request to '" + response.url + "':")
+            print(response.text)
+            return None
+    except Exception as e:
+        print("😡 An exception occurred while sending '" + method + "' request to '" + endpoint + "': " + str(e))
         return None
+
 
 def updateIPs(ips):
     for ip in ips.values():


### PR DESCRIPTION
Pod was restarting when exception thrown.
Add try except block for cf_api method api call to handle the exception.

🕰️ Updating IPv4 (A) & IPv6 (AAAA) records every 5 minutes
--
  |   | requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='api.cloudflare.com', port=443): Read timed out. (read timeout=None)
  |   | raise ReadTimeout(e, request=request)
  |   | File "/usr/local/lib/python3.10/site-packages/requests/adapters.py", line 529, in send
  |   | r = adapter.send(request, **kwargs)
  |   | File "/usr/local/lib/python3.10/site-packages/requests/sessions.py", line 655, in send
  |   | resp = self.send(prep, **send_kwargs)
  |   | File "/usr/local/lib/python3.10/site-packages/requests/sessions.py", line 542, in request
  |   | return session.request(method=method, url=url, **kwargs)
  |   | File "/usr/local/lib/python3.10/site-packages/requests/api.py", line 61, in request
  |   | response = requests.request(
  |   | File "/cloudflare-ddns.py", line 165, in cf_api
  |   | dns_records = cf_api(
  |   | File "/cloudflare-ddns.py", line 110, in commitRecord
  |   | commitRecord(ip)
  |   | File "/cloudflare-ddns.py", line 181, in updateIPs
  |   | updateIPs(getIPs())
  |   | File "/cloudflare-ddns.py", line 227, in <module>
  |   | Traceback (most recent call last):