### PR TITLE
Added per-subdomain proxy switch

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -32,7 +32,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: timothyjmiller/cloudflare-ddns
+          images: jgkawell/cloudflare-ddns
           sep-tags: ','
           flavor: |
             latest=false

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -32,7 +32,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: jgkawell/cloudflare-ddns
+          images: timothyjmiller/cloudflare-ddns
           sep-tags: ','
           flavor: |
             latest=false

--- a/README.md
+++ b/README.md
@@ -105,10 +105,15 @@ Do not include the base domain name in your `subdomains` config. Do not use the 
       },
       "zone_id": "your_zone_id_here",
       "subdomains": [
-        "",
-        "remove_or_replace_with_your_subdomain"
+        {
+          "name": "",
+          "proxied": false
+        },
+        {
+          "name": "remove_or_replace_with_your_subdomain",
+          "proxied": false
+        }
       ],
-      "proxied": true
     },
     {
       "authentication": {
@@ -120,10 +125,15 @@ Do not include the base domain name in your `subdomains` config. Do not use the 
       },
       "zone_id": "your_zone_id_here",
       "subdomains": [
-        "",
-        "remove_or_replace_with_your_subdomain"
+        {
+          "name": "",
+          "proxied": true
+        },
+        {
+          "name": "remove_or_replace_with_your_subdomain",
+          "proxied": true
+        }
       ],
-      "proxied": true
     }
   ]
 }

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -99,20 +99,20 @@ def commitRecord(ip):
         base_domain_name = response["result"]["name"]
         ttl = 300 # default Cloudflare TTL
         for subdomain in subdomains:
-            subdomain = subdomain.lower().strip()
+            name = subdomain["name"].lower().strip()
             record = {
                 "type": ip["type"],
-                "name": subdomain,
+                "name": name,
                 "content": ip["ip"],
-                "proxied": option["proxied"],
+                "proxied": subdomain["proxied"],
                 "ttl": ttl
             }
             dns_records = cf_api(
                 "zones/" + option['zone_id'] + "/dns_records?per_page=100&type=" + ip["type"], 
                 "GET", option)
             fqdn = base_domain_name
-            if subdomain:
-                fqdn = subdomain + "." + base_domain_name
+            if name:
+                fqdn = name + "." + base_domain_name
             identifier = None
             modified = False
             duplicate_ids = []

--- a/config-example.json
+++ b/config-example.json
@@ -10,8 +10,14 @@
       },
       "zone_id": "your_zone_id_here",
       "subdomains": [
-        "",
-        "remove_or_replace_with_your_subdomain"
+        {
+          "name": "",
+          "proxied": false
+        },
+        {
+          "name": "remove_or_replace_with_your_subdomain",
+          "proxied": false
+        }
       ],
       "proxied": false
     }


### PR DESCRIPTION
This PR adds the requested functionality in #30 and #77 to add the proxy status on a per-subdomain basis.

I built this using the GitHub action on my branch and tested that image in my HomeLab `k3s` cluster: https://hub.docker.com/repository/docker/jgkawell/cloudflare-ddns

It worked great and I was able to set some subdomains to have the proxy enabled and others to disabled all under the same cloudflare object in the config.

The code change is slight, and I've updated all the example configs:

```json
  "subdomains": [
    {
      "name": "",
      "proxied": false
    },
    {
      "name": "remove_or_replace_with_your_subdomain",
      "proxied": false
    }
  ]
```