### PR TITLE
Fix issue #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can handle ddns for multiple domains (cloudflare zones) using the same docke
 
 ### ⚠️ Note
 
-Do not include the base domain name in your `subdomains` config. Do not use the [FDQN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name).
+Use `@` in your `subdomains` config if you want to set your base domain name. Do not use the [FDQN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name).
 
 ```bash
 {
@@ -120,7 +120,7 @@ Do not include the base domain name in your `subdomains` config. Do not use the 
       },
       "zone_id": "your_zone_id_here",
       "subdomains": [
-        "",
+        "@",
         "remove_or_replace_with_your_subdomain"
       ],
       "proxied": true

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -112,7 +112,7 @@ def commitRecord(ip):
                 "GET", option)
             fqdn = base_domain_name
             if subdomain:
-                fqdn = subdomain + "." + base_domain_name
+                fqdn = subdomain + "." + base_domain_name if subdomain != "@" else base_domain_name
             identifier = None
             modified = False
             duplicate_ids = []


### PR DESCRIPTION
This fixes #91 .

This fix requires you to enter `@` as subdomain in your config file if you want to update the DNS entry for your zone apex.  
The usage is similar to what you would enter in the webinterface or what is described in the API docs [1]

[1] https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
