### PR TITLE
Fix support for wildcard subdomains

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -114,7 +114,7 @@ def commitRecord(ip):
                 proxied = option["proxied"]
             fqdn = base_domain_name
             # Check if name provided is a reference to the root domain
-            if name != '' and name != '*' and name != '@':
+            if name != '' and name != '@':
                 fqdn = name + "." + base_domain_name
             record = {
                 "type": ip["type"],


### PR DESCRIPTION
Wildcard subdomain support was broken because `*` was treated as a reference to the root domain, which it is not. This change makes it so that a subdomain of `*` for a zone of `domain.com` has a fqdn of `*.domain.com`, instead of `domain.com`, 
