### PR TITLE
Update interpreter of shebang to python3

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #   cloudflare-ddns.py
 #   Summary: Access your home network remotely via a custom domain name without a static IP!
 #   Description: Access your home network remotely via a custom domain


### PR DESCRIPTION
Some distros like Ubuntu don't treat `python` as `python3` by default, which require additional packages like `python-is-python3` to make the symbolic link applied.

Since the version of cloudflare-ddns.py is [limited to 3.5 or later](https://github.com/timothymiller/cloudflare-ddns/blob/b0a396b8f1dade307c38c7cad1d35398565410e3/cloudflare-ddns.py#L213-L215), `python3` can be used as the interpreter of shebang without emerging compatibility issues.