### PR TITLE
[feature] Support for environmental substitution in config.json 

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,19 @@ Do not include the base domain name in your `subdomains` config. Do not use the 
 }
 ```
 
-### 🗣️ Call to action: Docker environment variable support
+### Docker environment variable support
 
-I am looking for help adding Docker environment variable support to this project. If interested, check out [this comment](https://github.com/timothymiller/cloudflare-ddns/pull/35#issuecomment-974752476) and open a PR.
+Define environmental variables starts with `CF_DDNS_` and use it in config.json
+
+For ex:
+
+```json
+{
+  "cloudflare": [
+    {
+      "authentication": {
+        "api_token": "${CF_DDNS_API_TOKEN}",
+```
 
 ## 🐳 Deploy with Docker Compose
 

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -8,6 +8,8 @@
 
 __version__ = "1.0.2"
 
+from string import Template
+
 import json
 import os
 import signal
@@ -17,7 +19,8 @@ import time
 import requests
 
 CONFIG_PATH = os.environ.get('CONFIG_PATH', os.getcwd())
-
+# Read in all environment variables that have the correct prefix
+ENV_VARS = {key: value for (key, value) in os.environ.items() if key.startswith('CF_DDNS_')}
 
 class GracefulExit:
     def __init__(self):
@@ -216,7 +219,7 @@ if __name__ == '__main__':
     config = None
     try:
         with open(os.path.join(CONFIG_PATH, "config.json")) as config_file:
-            config = json.loads(config_file.read())
+            config = json.loads(Template(config_file.read()).safe_substitute(ENV_VARS))
     except:
         print("😡 Error reading config.json")
         # wait 10 seconds to prevent excessive logging on docker auto restart

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -263,7 +263,10 @@ if __name__ == '__main__':
     config = None
     try:
         with open(os.path.join(CONFIG_PATH, "config.json")) as config_file:
-            config = json.loads(Template(config_file.read()).safe_substitute(ENV_VARS))
+            if len(ENV_VARS) != 0:
+                config = json.loads(Template(config_file.read()).safe_substitute(ENV_VARS))
+            else:
+                config = json.loads(config_file.read())
     except:
         print("😡 Error reading config.json")
         # wait 10 seconds to prevent excessive logging on docker auto restart

--- a/scripts/docker-build-all.sh
+++ b/scripts/docker-build-all.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-docker buildx build --platform  linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest ../
+BASH_DIR=$(dirname $(realpath "${BASH_SOURCE}"))
+docker buildx build --platform  linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest ${BASH_DIR}/../
 # TODO: Support linux/riscv64

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker build --platform linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest ../
+BASH_DIR=$(dirname $(realpath "${BASH_SOURCE}"))
+docker build --platform linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest ${BASH_DIR}/../

--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker buildx build --platform linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest --push ../
+BASH_DIR=$(dirname $(realpath "${BASH_SOURCE}"))
+docker buildx build --platform linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64 --tag timothyjmiller/cloudflare-ddns:latest --push ${BASH_DIR}/../


### PR DESCRIPTION
This PR has

- support for environmental substitution in config.json using python Template. Refer comment in #35
- Allow to run the scripts from root/any folder. For ex `./scripts/docker-build.sh` 