### PR TITLE
Reduce Docker image size by only copying pip installed dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,13 @@ FROM python:alpine AS base
 FROM base AS dependencies
 # install dependencies
 COPY requirements.txt .
-RUN pip install -r requirements.txt
- 
+RUN pip install --user -r requirements.txt
+
 #
 # ---- Release ----
-FROM dependencies AS release
-# copy project source file(s)
+FROM base AS release
+# copy installed dependencies and project source file(s)
 WORKDIR /
+COPY --from=dependencies /root/.local /root/.local
 COPY cloudflare-ddns.py .
 CMD ["python", "-u", "/cloudflare-ddns.py", "--repeat"]


### PR DESCRIPTION
Currently, the multi-stage Docker build makes the `release` stage inherit from `dependencies`, which will include any files created by the `pip install` process in the final image.

By using `pip install --user` to make dependencies be installed in `~/.local`, we can only copy those files into the final image, reducing the image size:

```
cloudflare-ddns-fix-applied     latest            68427bd7c88d   3 minutes ago   54.6MB
cloudflare-ddns-master          latest            2675320b651d   8 minutes ago   65.9MB
```

A good resource to go deeper on how this approach works can be found at https://pythonspeed.com/articles/multi-stage-docker-python/, solution 1.