### PR TITLE
[feature] Add script method to get ip address

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -21,8 +21,20 @@
       ]
     }
   ],
-  "a": true,
-  "aaaa": true,
+  "ip": {
+    "a": {
+      "enabled": true,
+      "method": "http", // or "netif" or "script"
+      "interface": "eth0", // interface name to get IPv4 address, used in interface mode
+      "script": "script_v4.sh" // path to script to get IPv4 address
+    },
+    "aaaa": {
+      "enabled": true,
+      "method": "http",
+      "interface": "eth0",
+      "script": "script_v6.sh"
+    }
+  },
   "purgeUnknownRecords": false,
   "ttl": 300
 }


### PR DESCRIPTION
Allow running custom scripts to get both IPv4 and IPv6 address by Python lib `subprocess`, and validate the output of custom scripts with lib `ipaddress` (all Python standard libraries)

Given that there will be three ways to obtain an IP address in the future, I have partially refactored the configuration file format. The new configuration file format is as follows:

```json
"ip": {
    "a": {
      "enabled": true,
      "method": "http", // or "netif" or "script"
      "interface": "eth0", // interface name to get IPv4 address, used in interface mode
      "script": "script_v4.sh" // path to script to get IPv4 address
    },
    "aaaa": {
      "enabled": true,
      "method": "http",
      "interface": "eth0",
      "script": "script_v6.sh"
    }
  }
```

This is just a tentative configuration file scheme. Personally, I think that although it may seem a bit bulky, it looks clearer.