### PR TITLE
feat(ttl): allow for auto TTL value

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -285,26 +285,28 @@ if __name__ == '__main__':
             ttl = 300  # default Cloudflare TTL
             print(
                 "⚙️ No config detected for 'ttl' - defaulting to 300 seconds (5 minutes)")
-        if ttl < 30:
+        if ttl < 30 and ttl != 1:
             ttl = 30  #
             print("⚙️ TTL is too low - defaulting to 30 seconds")
         if (len(sys.argv) > 1):
             if (sys.argv[1] == "--repeat"):
+                wait = ttl if ttl >= 30 else 30
+                ttl_str = str(wait)
                 if ipv4_enabled and ipv6_enabled:
                     print(
-                        "🕰️ Updating IPv4 (A) & IPv6 (AAAA) records every " + str(ttl) + " seconds")
+                        "🕰️ Updating IPv4 (A) & IPv6 (AAAA) records every " + ttl_str + " seconds")
                 elif ipv4_enabled and not ipv6_enabled:
                     print("🕰️ Updating IPv4 (A) records every " +
-                          str(ttl) + " seconds")
+                          ttl_str + " seconds")
                 elif ipv6_enabled and not ipv4_enabled:
                     print("🕰️ Updating IPv6 (AAAA) records every " +
-                          str(ttl) + " seconds")
+                          ttl_str + " seconds")
                 next_time = time.time()
                 killer = GracefulExit()
                 prev_ips = None
                 while True:
                     updateIPs(getIPs())
-                    if killer.kill_now.wait(ttl):
+                    if killer.kill_now.wait(wait):
                         break
             else:
                 print("❓ Unrecognized parameter '" +


### PR DESCRIPTION
Cloudflare uses a value of "1" to denote an auto TTL on the DNS record via API