### PR TITLE
Update README to fix the location where `docker-compose up -d` should…

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Docker requires network_mode be set to host in order to access the IPv6 public a
 
 ### 🏃‍♂️ Running
 
-From the project root directory
+From the `docker` directory
 
 ```bash
 docker-compose up -d


### PR DESCRIPTION
… be run

`docker-compose` is looking for `docker-compose.yml`, which is not under the project root directory, but the `docker` directory.