### PR TITLE
Add a comment referencing the update time

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -15,6 +15,7 @@ import sys
 import threading
 import time
 import requests
+from datetime import datetime
 
 CONFIG_PATH = os.environ.get('CONFIG_PATH', os.getcwd())
 
@@ -137,12 +138,14 @@ def commitRecord(ip):
             # Check if name provided is a reference to the root domain
             if name != '' and name != '@':
                 fqdn = name + "." + base_domain_name
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             record = {
                 "type": ip["type"],
                 "name": fqdn,
                 "content": ip["ip"],
                 "proxied": proxied,
-                "ttl": ttl
+                "ttl": ttl,
+                "comment": f"Updated by CloudflareDDNS at {timestamp}."
             }
             dns_records = cf_api(
                 "zones/" + option['zone_id'] +


### PR DESCRIPTION
Adds a comment to the DNS record(s) referencing the timestamp where the update occurred.

![image](https://github.com/timothymiller/cloudflare-ddns/assets/25354036/8b585956-8c7c-4999-851f-a6ecbcf51584)
