### PR TITLE
Added debug exception print when reading config.json

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -261,8 +261,8 @@ if __name__ == '__main__':
     try:
         with open(os.path.join(CONFIG_PATH, "config.json")) as config_file:
             config = json.loads(config_file.read())
-    except:
-        print("😡 Error reading config.json")
+    except Exception as e:
+        print(f"😡 Error reading config.json {str(e)}")
         # wait 10 seconds to prevent excessive logging on docker auto restart
         time.sleep(10)
 


### PR DESCRIPTION
# ⚠️ PLEASE TEST THOSE CHANGES FIRST

I didn't manage to get it to run, recently switched to Linux and still experiencing some issues.

But I need those changes, because I have no clue why I get a `config.json` error: #129 