### PR TITLE
Zarthcode custom table scraper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.31.0
+beautifulsoup4==4.12.3


### PR DESCRIPTION
My router has a locally accessible webpage that presents the public ipv6 and ipv4 addresses in a table format.  This patch allows for accessing an arbitrary url and looking for the element after given table headers using the config variables scraper_url, scraper_ipv4_label, and scraper_ipv6_label.

e.g. for an ATT BGW320-500 router, the following config.json will acquire the ipv4 and v6 addresses:

```
{
  "cloudflare": [
    {
      "authentication": {
        "api_token": "your secret token"
      },
      "zone_id": "your zone id",
      "subdomains": [
        {
          "name": "www",
          "proxied": true
        }
      ]
    }
  ],
  "scrape_url": "http://192.168.1.254/cgi-bin/broadbandstatistics.ha",
  "scrape_ipv4_label": "Broadband IPv4 Address",
  "scrape_ipv6_label": "Global Unicast IPv6 Address",
  "a": true,
  "aaaa": true,
  "purgeUnknownRecords": false,
  "ttl": 300
}
```

This is a much less intrusive way to acquire ip information - if your gateway/router provides this information readily. 