### PR TITLE
Fix record update attempt with invalid IP

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -74,10 +74,7 @@ def getIPs():
     global purgeUnknownRecords
     if ipv4_enabled:
         try:
-            a = requests.get(
-                "https://1.1.1.1/cdn-cgi/trace").text.split("\n")
-            a.pop()
-            a = dict(s.split("=") for s in a)["ip"]
+            a = getIP("https://1.1.1.1/cdn-cgi/trace")
         except Exception:
             global shown_ipv4_warning
             if not shown_ipv4_warning:
@@ -85,10 +82,7 @@ def getIPs():
                 print("🧩 IPv4 not detected via 1.1.1.1, trying 1.0.0.1")
             # Try secondary IP check
             try:
-                a = requests.get(
-                    "https://1.0.0.1/cdn-cgi/trace").text.split("\n")
-                a.pop()
-                a = dict(s.split("=") for s in a)["ip"]
+                a = getIP("https://1.0.0.1/cdn-cgi/trace")
             except Exception:
                 global shown_ipv4_warning_secondary
                 if not shown_ipv4_warning_secondary:
@@ -98,20 +92,15 @@ def getIPs():
                     deleteEntries("A")
     if ipv6_enabled:
         try:
-            aaaa = requests.get(
-                "https://[2606:4700:4700::1111]/cdn-cgi/trace").text.split("\n")
-            aaaa.pop()
-            aaaa = dict(s.split("=") for s in aaaa)["ip"]
+            aaaa = getIP("https://[2606:4700:4700::1111]/cdn-cgi/trace")
         except Exception:
             global shown_ipv6_warning
             if not shown_ipv6_warning:
                 shown_ipv6_warning = True
                 print("🧩 IPv6 not detected via 1.1.1.1, trying 1.0.0.1")
+            # Try secondary IP check
             try:
-                aaaa = requests.get(
-                    "https://[2606:4700:4700::1001]/cdn-cgi/trace").text.split("\n")
-                aaaa.pop()
-                aaaa = dict(s.split("=") for s in aaaa)["ip"]
+                aaaa = getIP("https://[2606:4700:4700::1001]/cdn-cgi/trace")
             except Exception:
                 global shown_ipv6_warning_secondary
                 if not shown_ipv6_warning_secondary:

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -53,6 +53,19 @@ def deleteEntries(type):
             print("🗑️ Deleted stale record " + identifier)
 
 
+def getIP(endpoint, **kwargs):
+    # Helper function for getting IPv4 or IPv6 address
+    # from a specified endpoint. Raises an error
+    # in the case of a response or return value failure.
+    timeout = kwargs.get("timeout", 10)
+    response = requests.get(endpoint, timeout=timeout)
+    # raise any error status
+    response.raise_for_status()
+    # create list out of response
+    l = [line for line in response.text.split("\n") if line.strip()]
+    return dict(i.split("=") for i in l)["ip"]
+
+
 def getIPs():
     a = None
     aaaa = None


### PR DESCRIPTION
# Changes

- Moved repetitive code used to determine IPv4 and IPv6 address into its own helper function to make it more "centralised" (in case we plan to introduce a more complex/robust solution in the future)
- This helper function also ensures that error codes returned by the endpoint we're relying on are raised, which fixes the current behaviour of repeated attempts to update records with error responses (returned by the endpoint i.e. `https://1.1.1.1/cdn-cgi/trace`)

# Issues addressed

- #202 - **Only partially**: It does not (yet) fix the fact that the image currently is not able to determine the IPv4 address, due to the 2 endpoints currently being used, `https://1.1.1.1/cdn-cgi/trace` and `https://1.0.0.1/cdn-cgi/trace`, are not working as intended.

Ideally, a fallback will be introduced (possibly through the new `getIP` helper function) that can be used in place of the 2 current endpoints (for IPv4).

# Testing

I've published a public Docker image on my fork repository that can be used to test this PR: https://github.com/irfanhakim-as/cloudflare-ddns/pkgs/container/cloudflare-ddns