### PR TITLE
Ensure the Deployment is created in the ddns namespace.

### DIFF
--- a/k8s/cloudflare-ddns.yml
+++ b/k8s/cloudflare-ddns.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cloudflare-ddns
+  namespace: ddns
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
The config-cloudflare-ddns-Secret.yaml is being created in the ddns namespace, while the Deployment is being created in the default namespace. This causes the Deployment to fail to become ready.

inside of config-cloudflare-ddns-Secret.yaml:
![image](https://github.com/user-attachments/assets/7810a9f7-ad4a-4b15-b2d1-6536ee9e2f39)
