### PR TITLE
feat: Add Docker-based dynamic domain discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bollard"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.53.1-rc.29.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +137,7 @@ dependencies = [
 name = "cloudflare-ddns"
 version = "2.1.2"
 dependencies = [
+ "bollard",
  "if-addrs",
  "rand",
  "regex-lite",
@@ -380,6 +424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +498,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +549,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -649,7 +729,7 @@ dependencies = [
  "combine",
  "jni-sys 0.3.1",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -1120,6 +1200,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,7 +1322,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1239,6 +1339,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1567,6 +1678,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,6 +1701,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ regex-lite = "0.1"
 url = "2"
 if-addrs = "0.15"
 rand = "0.10"
+bollard = "0.21.0"
 
 [profile.release]
 opt-level = "z"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Configure everything with environment variables. Supports notifications, heartbe
 - 🔒 **Zero-log IP detection** — Uses Cloudflare's [cdn-cgi/trace](https://www.cloudflare.com/cdn-cgi/trace) by default
 - 🏠 **CGNAT-aware local detection** — Filters out shared address space (100.64.0.0/10) and private ranges
 - 🚫 **Cloudflare IP rejection** — Automatically rejects Cloudflare anycast IPs to prevent incorrect DNS updates
+- 🐳 **Docker domain discovery** — Automatically discover domains from Docker container labels
 - 🤏 **Tiny static binary** — ~1.1 MB Docker image built from scratch, zero runtime dependencies
 
 ## 🚀 Quick Start
@@ -58,15 +59,40 @@ To generate an API token, go to your [Cloudflare Profile](https://dash.cloudflar
 
 ## 🌐 Domains
 
-| Variable | Description |
-|----------|-------------|
-| `DOMAINS` | Comma-separated list of domains to update for both IPv4 and IPv6 |
-| `IP4_DOMAINS` | Comma-separated list of IPv4-only domains |
-| `IP6_DOMAINS` | Comma-separated list of IPv6-only domains |
+| Variable      | Description                                                      |
+| ------------- | ---------------------------------------------------------------- |
+| `DOMAINS`     | Comma-separated list of domains to update for both IPv4 and IPv6 |
+| `IP4_DOMAINS` | Comma-separated list of IPv4-only domains                        |
+| `IP6_DOMAINS` | Comma-separated list of IPv6-only domains                        |
+| `DOCKER_HOST` | Docker socket path for automatic domain discovery                |
 
 Wildcard domains are supported: `*.example.com`
 
-At least one of `DOMAINS`, `IP4_DOMAINS`, `IP6_DOMAINS`, or `WAF_LISTS` must be set.
+At least one of `DOMAINS`, `IP4_DOMAINS`, `IP6_DOMAINS`, `DOCKER_HOST`, or `WAF_LISTS` must be set.
+
+### 🐳 Docker Domain Discovery
+
+When `DOCKER_HOST` is set to a Docker socket path (e.g., `unix:///var/run/docker.sock`), the tool will automatically discover domains from Docker container label `ddns.domain`.
+
+```yaml
+version: '3.9'
+services:
+  ddns:
+    image: timothyjmiller/cloudflare-ddns:latest
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+
+  my-app:
+    image: my-image:latest
+    labels:
+      - 'ddns.domain=app.example.com'
+```
+
+Discovered domains are combined with statically configured `DOMAINS`, `IP4_DOMAINS`, and `IP6_DOMAINS`. When containers are removed or labels change, the tool automatically removes their DNS records if `DELETE_ON_STOP` is enabled.
 
 ## 🔍 IP Detection Providers
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Heartbeats are sent after each update cycle. On failure, a fail signal is sent. 
 | `DOMAINS` | — | 🌐 Domains for both IPv4 and IPv6 |
 | `IP4_DOMAINS` | — | 4️⃣ IPv4-only domains |
 | `IP6_DOMAINS` | — | 6️⃣ IPv6-only domains |
+| `DOCKER_HOST` | — | 🐳 Docker socket path for domain discovery |
 | `IP4_PROVIDER` | `ipify` | 🔍 IPv4 detection provider |
 | `IP6_PROVIDER` | `cloudflare.trace` | 🔍 IPv6 detection provider |
 | `UPDATE_CRON` | `@every 5m` | ⏱️ Update schedule |

--- a/src/cloudflare.rs
+++ b/src/cloudflare.rs
@@ -64,12 +64,17 @@ impl WAFList {
     pub fn parse(input: &str) -> Result<Self, String> {
         let parts: Vec<&str> = input.splitn(2, '/').collect();
         if parts.len() != 2 {
-            return Err(format!("WAF list must be in format 'account-id/list-name': {input}"));
+            return Err(format!(
+                "WAF list must be in format 'account-id/list-name': {input}"
+            ));
         }
         let account_id = parts[0].trim().to_string();
         let list_name = parts[1].trim().to_string();
 
-        if !list_name.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_') {
+        if !list_name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        {
             return Err(format!("WAF list name must match [a-z0-9_]+: {list_name}"));
         }
 
@@ -148,6 +153,7 @@ pub struct WAFListCreateItem {
 
 // --- Cloudflare API Handle ---
 
+#[derive(Debug, Clone)]
 pub struct CloudflareHandle {
     client: Client,
     base_url: String,
@@ -178,10 +184,7 @@ impl CloudflareHandle {
     }
 
     #[cfg(test)]
-    pub fn with_base_url(
-        base_url: &str,
-        auth: Auth,
-    ) -> Self {
+    pub fn with_base_url(base_url: &str, auth: Auth) -> Self {
         crate::init_crypto();
         let client = Client::builder()
             .timeout(Duration::from_secs(10))
@@ -220,12 +223,18 @@ impl CloudflareHandle {
                 } else {
                     let url_str = resp.url().to_string();
                     let text = resp.text().await.unwrap_or_default();
-                    ppfmt.errorf(pp::EMOJI_ERROR, &format!("API {method} '{url_str}' failed: {text}"));
+                    ppfmt.errorf(
+                        pp::EMOJI_ERROR,
+                        &format!("API {method} '{url_str}' failed: {text}"),
+                    );
                     None
                 }
             }
             Err(e) => {
-                ppfmt.errorf(pp::EMOJI_ERROR, &format!("API {method} '{path}' error: {e}"));
+                ppfmt.errorf(
+                    pp::EMOJI_ERROR,
+                    &format!("API {method} '{path}' error: {e}"),
+                );
                 None
             }
         }
@@ -238,7 +247,12 @@ impl CloudflareHandle {
         let mut current = domain.to_string();
         loop {
             let resp: Option<CfListResponse<ZoneResult>> = self
-                .api_request(reqwest::Method::GET, &format!("zones?name={current}"), None::<&()>, ppfmt)
+                .api_request(
+                    reqwest::Method::GET,
+                    &format!("zones?name={current}"),
+                    None::<&()>,
+                    ppfmt,
+                )
                 .await;
             if let Some(r) = resp {
                 if let Some(zones) = r.result {
@@ -269,7 +283,9 @@ impl CloudflareHandle {
         ppfmt: &PP,
     ) -> Vec<DnsRecord> {
         let path = format!("zones/{zone_id}/dns_records?per_page=100&type={record_type}");
-        let resp: Option<CfListResponse<DnsRecord>> = self.api_request(reqwest::Method::GET, &path, None::<&()>, ppfmt).await;
+        let resp: Option<CfListResponse<DnsRecord>> = self
+            .api_request(reqwest::Method::GET, &path, None::<&()>, ppfmt)
+            .await;
         resp.and_then(|r| r.result).unwrap_or_default()
     }
 
@@ -309,7 +325,9 @@ impl CloudflareHandle {
         ppfmt: &PP,
     ) -> Option<DnsRecord> {
         let path = format!("zones/{zone_id}/dns_records");
-        let resp: Option<CfResponse<DnsRecord>> = self.api_request(reqwest::Method::POST, &path, Some(payload), ppfmt).await;
+        let resp: Option<CfResponse<DnsRecord>> = self
+            .api_request(reqwest::Method::POST, &path, Some(payload), ppfmt)
+            .await;
         resp.and_then(|r| r.result)
     }
 
@@ -321,18 +339,17 @@ impl CloudflareHandle {
         ppfmt: &PP,
     ) -> Option<DnsRecord> {
         let path = format!("zones/{zone_id}/dns_records/{record_id}");
-        let resp: Option<CfResponse<DnsRecord>> = self.api_request(reqwest::Method::PUT, &path, Some(payload), ppfmt).await;
+        let resp: Option<CfResponse<DnsRecord>> = self
+            .api_request(reqwest::Method::PUT, &path, Some(payload), ppfmt)
+            .await;
         resp.and_then(|r| r.result)
     }
 
-    pub async fn delete_record(
-        &self,
-        zone_id: &str,
-        record_id: &str,
-        ppfmt: &PP,
-    ) -> bool {
+    pub async fn delete_record(&self, zone_id: &str, record_id: &str, ppfmt: &PP) -> bool {
         let path = format!("zones/{zone_id}/dns_records/{record_id}");
-        let resp: Option<CfResponse<serde_json::Value>> = self.api_request(reqwest::Method::DELETE, &path, None::<&()>, ppfmt).await;
+        let resp: Option<CfResponse<serde_json::Value>> = self
+            .api_request(reqwest::Method::DELETE, &path, None::<&()>, ppfmt)
+            .await;
         resp.is_some()
     }
 
@@ -349,8 +366,13 @@ impl CloudflareHandle {
         dry_run: bool,
         ppfmt: &PP,
     ) -> SetResult {
-        let existing = self.list_records_by_name(zone_id, record_type, fqdn, ppfmt).await;
-        let managed: Vec<&DnsRecord> = existing.iter().filter(|r| self.is_managed_record(r)).collect();
+        let existing = self
+            .list_records_by_name(zone_id, record_type, fqdn, ppfmt)
+            .await;
+        let managed: Vec<&DnsRecord> = existing
+            .iter()
+            .filter(|r| self.is_managed_record(r))
+            .collect();
 
         if ips.is_empty() {
             // Delete all managed records
@@ -359,9 +381,15 @@ impl CloudflareHandle {
             }
             for record in &managed {
                 if dry_run {
-                    ppfmt.noticef(pp::EMOJI_DELETE, &format!("[DRY RUN] Would delete record {fqdn} ({})", record.content));
+                    ppfmt.noticef(
+                        pp::EMOJI_DELETE,
+                        &format!("[DRY RUN] Would delete record {fqdn} ({})", record.content),
+                    );
                 } else {
-                    ppfmt.noticef(pp::EMOJI_DELETE, &format!("Deleting record {fqdn} ({})", record.content));
+                    ppfmt.noticef(
+                        pp::EMOJI_DELETE,
+                        &format!("Deleting record {fqdn} ({})", record.content),
+                    );
                     self.delete_record(zone_id, &record.id, ppfmt).await;
                 }
             }
@@ -376,9 +404,9 @@ impl CloudflareHandle {
             let ip_str = ip.to_string();
 
             // Find existing record with this IP
-            let matching = managed.iter().find(|r| {
-                r.content == ip_str && !used_record_ids.contains(&&r.id)
-            });
+            let matching = managed
+                .iter()
+                .find(|r| r.content == ip_str && !used_record_ids.contains(&&r.id));
 
             if let Some(record) = matching {
                 used_record_ids.push(&record.id);
@@ -398,19 +426,24 @@ impl CloudflareHandle {
                         comment: comment.map(|s| s.to_string()),
                     };
                     if dry_run {
-                        ppfmt.noticef(pp::EMOJI_UPDATE, &format!("[DRY RUN] Would update record {fqdn} -> {ip_str}"));
+                        ppfmt.noticef(
+                            pp::EMOJI_UPDATE,
+                            &format!("[DRY RUN] Would update record {fqdn} -> {ip_str}"),
+                        );
                     } else {
-                        ppfmt.noticef(pp::EMOJI_UPDATE, &format!("Updating record {fqdn} -> {ip_str}"));
-                        self.update_record(zone_id, &record.id, &payload, ppfmt).await;
+                        ppfmt.noticef(
+                            pp::EMOJI_UPDATE,
+                            &format!("Updating record {fqdn} -> {ip_str}"),
+                        );
+                        self.update_record(zone_id, &record.id, &payload, ppfmt)
+                            .await;
                     }
                 } else {
                     // Caller handles "up to date" logging based on SetResult::Noop
                 }
             } else {
                 // Find an existing managed record to update, or create new
-                let reusable = managed.iter().find(|r| {
-                    !used_record_ids.contains(&&r.id)
-                });
+                let reusable = managed.iter().find(|r| !used_record_ids.contains(&&r.id));
 
                 let payload = DnsRecordPayload {
                     record_type: record_type.to_string(),
@@ -425,17 +458,30 @@ impl CloudflareHandle {
                     used_record_ids.push(&record.id);
                     any_change = true;
                     if dry_run {
-                        ppfmt.noticef(pp::EMOJI_UPDATE, &format!("[DRY RUN] Would update record {fqdn} -> {ip_str}"));
+                        ppfmt.noticef(
+                            pp::EMOJI_UPDATE,
+                            &format!("[DRY RUN] Would update record {fqdn} -> {ip_str}"),
+                        );
                     } else {
-                        ppfmt.noticef(pp::EMOJI_UPDATE, &format!("Updating record {fqdn} -> {ip_str}"));
-                        self.update_record(zone_id, &record.id, &payload, ppfmt).await;
+                        ppfmt.noticef(
+                            pp::EMOJI_UPDATE,
+                            &format!("Updating record {fqdn} -> {ip_str}"),
+                        );
+                        self.update_record(zone_id, &record.id, &payload, ppfmt)
+                            .await;
                     }
                 } else {
                     any_change = true;
                     if dry_run {
-                        ppfmt.noticef(pp::EMOJI_CREATE, &format!("[DRY RUN] Would add new record {fqdn} -> {ip_str}"));
+                        ppfmt.noticef(
+                            pp::EMOJI_CREATE,
+                            &format!("[DRY RUN] Would add new record {fqdn} -> {ip_str}"),
+                        );
                     } else {
-                        ppfmt.noticef(pp::EMOJI_CREATE, &format!("Adding new record {fqdn} -> {ip_str}"));
+                        ppfmt.noticef(
+                            pp::EMOJI_CREATE,
+                            &format!("Adding new record {fqdn} -> {ip_str}"),
+                        );
                         self.create_record(zone_id, &payload, ppfmt).await;
                     }
                 }
@@ -447,9 +493,18 @@ impl CloudflareHandle {
             if !used_record_ids.contains(&&record.id) {
                 any_change = true;
                 if dry_run {
-                    ppfmt.noticef(pp::EMOJI_DELETE, &format!("[DRY RUN] Would delete stale record {} ({})", fqdn, record.content));
+                    ppfmt.noticef(
+                        pp::EMOJI_DELETE,
+                        &format!(
+                            "[DRY RUN] Would delete stale record {} ({})",
+                            fqdn, record.content
+                        ),
+                    );
                 } else {
-                    ppfmt.noticef(pp::EMOJI_DELETE, &format!("Deleting stale record {} ({})", fqdn, record.content));
+                    ppfmt.noticef(
+                        pp::EMOJI_DELETE,
+                        &format!("Deleting stale record {} ({})", fqdn, record.content),
+                    );
                     self.delete_record(zone_id, &record.id, ppfmt).await;
                 }
             }
@@ -463,17 +518,16 @@ impl CloudflareHandle {
     }
 
     /// Delete all managed records for a specific domain/record type.
-    pub async fn final_delete(
-        &self,
-        zone_id: &str,
-        fqdn: &str,
-        record_type: &str,
-        ppfmt: &PP,
-    ) {
-        let existing = self.list_records_by_name(zone_id, record_type, fqdn, ppfmt).await;
+    pub async fn final_delete(&self, zone_id: &str, fqdn: &str, record_type: &str, ppfmt: &PP) {
+        let existing = self
+            .list_records_by_name(zone_id, record_type, fqdn, ppfmt)
+            .await;
         for record in &existing {
             if self.is_managed_record(record) {
-                ppfmt.noticef(pp::EMOJI_DELETE, &format!("Deleting record {fqdn} ({})", record.content));
+                ppfmt.noticef(
+                    pp::EMOJI_DELETE,
+                    &format!("Deleting record {fqdn} ({})", record.content),
+                );
                 self.delete_record(zone_id, &record.id, ppfmt).await;
             }
         }
@@ -481,13 +535,11 @@ impl CloudflareHandle {
 
     // --- WAF List Operations ---
 
-    pub async fn find_waf_list(
-        &self,
-        waf_list: &WAFList,
-        ppfmt: &PP,
-    ) -> Option<WAFListMeta> {
+    pub async fn find_waf_list(&self, waf_list: &WAFList, ppfmt: &PP) -> Option<WAFListMeta> {
         let path = format!("accounts/{}/rules/lists", waf_list.account_id);
-        let resp: Option<CfListResponse<WAFListMeta>> = self.api_request(reqwest::Method::GET, &path, None::<&()>, ppfmt).await;
+        let resp: Option<CfListResponse<WAFListMeta>> = self
+            .api_request(reqwest::Method::GET, &path, None::<&()>, ppfmt)
+            .await;
         resp.and_then(|r| r.result)
             .and_then(|lists| lists.into_iter().find(|l| l.name == waf_list.list_name))
     }
@@ -499,7 +551,9 @@ impl CloudflareHandle {
         ppfmt: &PP,
     ) -> Vec<WAFListItem> {
         let path = format!("accounts/{account_id}/rules/lists/{list_id}/items");
-        let resp: Option<CfListResponse<WAFListItem>> = self.api_request(reqwest::Method::GET, &path, None::<&()>, ppfmt).await;
+        let resp: Option<CfListResponse<WAFListItem>> = self
+            .api_request(reqwest::Method::GET, &path, None::<&()>, ppfmt)
+            .await;
         resp.and_then(|r| r.result).unwrap_or_default()
     }
 
@@ -511,7 +565,9 @@ impl CloudflareHandle {
         ppfmt: &PP,
     ) -> bool {
         let path = format!("accounts/{account_id}/rules/lists/{list_id}/items");
-        let resp: Option<CfResponse<serde_json::Value>> = self.api_request(reqwest::Method::POST, &path, Some(&items), ppfmt).await;
+        let resp: Option<CfResponse<serde_json::Value>> = self
+            .api_request(reqwest::Method::POST, &path, Some(&items), ppfmt)
+            .await;
         resp.is_some()
     }
 
@@ -528,11 +584,17 @@ impl CloudflareHandle {
             .map(|id| serde_json::json!({ "id": id }))
             .collect();
         let url = self.api_url(&path);
-        let req = self.auth.apply(self.client.delete(&url)).json(&serde_json::json!({ "items": body }));
+        let req = self
+            .auth
+            .apply(self.client.delete(&url))
+            .json(&serde_json::json!({ "items": body }));
         match req.send().await {
             Ok(resp) => resp.status().is_success(),
             Err(e) => {
-                ppfmt.errorf(pp::EMOJI_ERROR, &format!("WAF list items DELETE error: {e}"));
+                ppfmt.errorf(
+                    pp::EMOJI_ERROR,
+                    &format!("WAF list items DELETE error: {e}"),
+                );
                 false
             }
         }
@@ -566,14 +628,12 @@ impl CloudflareHandle {
         // Filter to managed items
         let managed_items: Vec<&WAFListItem> = existing_items
             .iter()
-            .filter(|item| {
-                match &self.managed_waf_comment_regex {
-                    Some(regex) => {
-                        let c = item.comment.as_deref().unwrap_or("");
-                        regex.is_match(c)
-                    }
-                    None => true,
+            .filter(|item| match &self.managed_waf_comment_regex {
+                Some(regex) => {
+                    let c = item.comment.as_deref().unwrap_or("");
+                    regex.is_match(c)
                 }
+                None => true,
             })
             .collect();
 
@@ -599,7 +659,9 @@ impl CloudflareHandle {
         let ids_to_delete: Vec<String> = managed_items
             .iter()
             .filter(|item| {
-                item.ip.as_ref().map_or(false, |ip| ips_to_remove.contains(ip))
+                item.ip
+                    .as_ref()
+                    .map_or(false, |ip| ips_to_remove.contains(ip))
             })
             .map(|item| item.id.clone())
             .collect();
@@ -613,13 +675,21 @@ impl CloudflareHandle {
             for item in &to_add {
                 ppfmt.noticef(
                     pp::EMOJI_CREATE,
-                    &format!("[DRY RUN] Would add {} to WAF list {}", item.ip, waf_list.describe()),
+                    &format!(
+                        "[DRY RUN] Would add {} to WAF list {}",
+                        item.ip,
+                        waf_list.describe()
+                    ),
                 );
             }
             for ip in &ips_to_remove {
                 ppfmt.noticef(
                     pp::EMOJI_DELETE,
-                    &format!("[DRY RUN] Would remove {} from WAF list {}", ip, waf_list.describe()),
+                    &format!(
+                        "[DRY RUN] Would remove {} from WAF list {}",
+                        ip,
+                        waf_list.describe()
+                    ),
                 );
             }
             return SetResult::Updated;
@@ -665,11 +735,7 @@ impl CloudflareHandle {
     }
 
     /// Clear all managed items from a WAF list (for shutdown).
-    pub async fn final_clear_waf_list(
-        &self,
-        waf_list: &WAFList,
-        ppfmt: &PP,
-    ) {
+    pub async fn final_clear_waf_list(&self, waf_list: &WAFList, ppfmt: &PP) {
         let list_meta = match self.find_waf_list(waf_list, ppfmt).await {
             Some(meta) => meta,
             None => return,
@@ -681,14 +747,12 @@ impl CloudflareHandle {
 
         let managed_ids: Vec<String> = items
             .iter()
-            .filter(|item| {
-                match &self.managed_waf_comment_regex {
-                    Some(regex) => {
-                        let c = item.comment.as_deref().unwrap_or("");
-                        regex.is_match(c)
-                    }
-                    None => true,
+            .filter(|item| match &self.managed_waf_comment_regex {
+                Some(regex) => {
+                    let c = item.comment.as_deref().unwrap_or("");
+                    regex.is_match(c)
                 }
+                None => true,
             })
             .map(|item| item.id.clone())
             .collect();
@@ -696,7 +760,11 @@ impl CloudflareHandle {
         if !managed_ids.is_empty() {
             ppfmt.noticef(
                 pp::EMOJI_DELETE,
-                &format!("Clearing {} items from WAF list {}", managed_ids.len(), waf_list.describe()),
+                &format!(
+                    "Clearing {} items from WAF list {}",
+                    managed_ids.len(),
+                    waf_list.describe()
+                ),
             );
             self.delete_waf_list_items(&waf_list.account_id, &list_meta.id, &managed_ids, ppfmt)
                 .await;
@@ -716,7 +784,10 @@ mod tests {
     use super::*;
     use crate::pp::PP;
     use std::net::IpAddr;
-    use wiremock::{Mock, MockServer, ResponseTemplate, matchers::{method, path, query_param}};
+    use wiremock::{
+        matchers::{method, path, query_param},
+        Mock, MockServer, ResponseTemplate,
+    };
 
     fn pp() -> PP {
         PP::new(false, false)
@@ -855,7 +926,12 @@ mod tests {
         serde_json::json!({ "result": [] })
     }
 
-    fn dns_record_json(id: &str, name: &str, content: &str, comment: Option<&str>) -> serde_json::Value {
+    fn dns_record_json(
+        id: &str,
+        name: &str,
+        content: &str,
+        comment: Option<&str>,
+    ) -> serde_json::Value {
         serde_json::json!({
             "id": id,
             "name": name,
@@ -888,7 +964,9 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/zones"))
             .and(query_param("name", "example.com"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(zone_response("zone-1", "example.com")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(zone_response("zone-1", "example.com")),
+            )
             .mount(&server)
             .await;
 
@@ -940,9 +1018,7 @@ mod tests {
     #[tokio::test]
     async fn list_records_by_name_case_insensitive() {
         let server = MockServer::start().await;
-        let body = dns_list_response(vec![
-            dns_record_json("r1", "example.com", "1.2.3.4", None),
-        ]);
+        let body = dns_list_response(vec![dns_record_json("r1", "example.com", "1.2.3.4", None)]);
         Mock::given(method("GET"))
             .and(path("/zones/z1/dns_records"))
             .respond_with(ResponseTemplate::new(200).set_body_json(body))
@@ -971,7 +1047,9 @@ mod tests {
             .await;
 
         let h = handle(&server.uri());
-        let records = h.list_records_by_name("z1", "A", "a.example.com", &pp()).await;
+        let records = h
+            .list_records_by_name("z1", "A", "a.example.com", &pp())
+            .await;
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].content, "1.2.3.4");
     }
@@ -1035,7 +1113,10 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("DELETE"))
             .and(path("/zones/z1/dns_records/r1"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": { "id": "r1" } })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "result": { "id": "r1" } })),
+            )
             .mount(&server)
             .await;
 
@@ -1057,16 +1138,31 @@ mod tests {
         // create
         Mock::given(method("POST"))
             .and(path("/zones/z1/dns_records"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                dns_single_response(dns_record_json("new1", "a.example.com", "1.2.3.4", None)),
-            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_single_response(dns_record_json(
+                    "new1",
+                    "a.example.com",
+                    "1.2.3.4",
+                    None,
+                ))),
+            )
             .mount(&server)
             .await;
 
         let h = handle(&server.uri());
         let ips: Vec<IpAddr> = vec!["1.2.3.4".parse().unwrap()];
         let result = h
-            .set_ips("z1", "a.example.com", "A", &ips, false, TTL::AUTO, None, false, &pp())
+            .set_ips(
+                "z1",
+                "a.example.com",
+                "A",
+                &ips,
+                false,
+                TTL::AUTO,
+                None,
+                false,
+                &pp(),
+            )
             .await;
         assert_eq!(result, SetResult::Updated);
     }
@@ -1078,16 +1174,31 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/zones/z1/dns_records"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
-                dns_record_json("r1", "a.example.com", "1.2.3.4", None),
-            ])))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_list_response(vec![dns_record_json(
+                    "r1",
+                    "a.example.com",
+                    "1.2.3.4",
+                    None,
+                )])),
+            )
             .mount(&server)
             .await;
 
         let h = handle(&server.uri());
         let ips: Vec<IpAddr> = vec!["1.2.3.4".parse().unwrap()];
         let result = h
-            .set_ips("z1", "a.example.com", "A", &ips, false, TTL::AUTO, None, false, &pp())
+            .set_ips(
+                "z1",
+                "a.example.com",
+                "A",
+                &ips,
+                false,
+                TTL::AUTO,
+                None,
+                false,
+                &pp(),
+            )
             .await;
         assert_eq!(result, SetResult::Noop);
     }
@@ -1099,23 +1210,43 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/zones/z1/dns_records"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
-                dns_record_json("r1", "a.example.com", "9.9.9.9", None),
-            ])))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_list_response(vec![dns_record_json(
+                    "r1",
+                    "a.example.com",
+                    "9.9.9.9",
+                    None,
+                )])),
+            )
             .mount(&server)
             .await;
         Mock::given(method("PUT"))
             .and(path("/zones/z1/dns_records/r1"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                dns_single_response(dns_record_json("r1", "a.example.com", "1.2.3.4", None)),
-            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_single_response(dns_record_json(
+                    "r1",
+                    "a.example.com",
+                    "1.2.3.4",
+                    None,
+                ))),
+            )
             .mount(&server)
             .await;
 
         let h = handle(&server.uri());
         let ips: Vec<IpAddr> = vec!["1.2.3.4".parse().unwrap()];
         let result = h
-            .set_ips("z1", "a.example.com", "A", &ips, false, TTL::AUTO, None, false, &pp())
+            .set_ips(
+                "z1",
+                "a.example.com",
+                "A",
+                &ips,
+                false,
+                TTL::AUTO,
+                None,
+                false,
+                &pp(),
+            )
             .await;
         assert_eq!(result, SetResult::Updated);
     }
@@ -1127,22 +1258,37 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/zones/z1/dns_records"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
-                dns_record_json("r1", "a.example.com", "1.2.3.4", None),
-                dns_record_json("r2", "a.example.com", "5.5.5.5", None),
-            ])))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
+                    dns_record_json("r1", "a.example.com", "1.2.3.4", None),
+                    dns_record_json("r2", "a.example.com", "5.5.5.5", None),
+                ])),
+            )
             .mount(&server)
             .await;
         Mock::given(method("DELETE"))
             .and(path("/zones/z1/dns_records/r2"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": { "id": "r2" } })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "result": { "id": "r2" } })),
+            )
             .mount(&server)
             .await;
 
         let h = handle(&server.uri());
         let ips: Vec<IpAddr> = vec!["1.2.3.4".parse().unwrap()];
         let result = h
-            .set_ips("z1", "a.example.com", "A", &ips, false, TTL::AUTO, None, false, &pp())
+            .set_ips(
+                "z1",
+                "a.example.com",
+                "A",
+                &ips,
+                false,
+                TTL::AUTO,
+                None,
+                false,
+                &pp(),
+            )
             .await;
         assert_eq!(result, SetResult::Updated);
     }
@@ -1154,21 +1300,39 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/zones/z1/dns_records"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
-                dns_record_json("r1", "a.example.com", "1.2.3.4", None),
-            ])))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_list_response(vec![dns_record_json(
+                    "r1",
+                    "a.example.com",
+                    "1.2.3.4",
+                    None,
+                )])),
+            )
             .mount(&server)
             .await;
         Mock::given(method("DELETE"))
             .and(path("/zones/z1/dns_records/r1"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": { "id": "r1" } })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "result": { "id": "r1" } })),
+            )
             .mount(&server)
             .await;
 
         let h = handle(&server.uri());
         let ips: Vec<IpAddr> = vec![];
         let result = h
-            .set_ips("z1", "a.example.com", "A", &ips, false, TTL::AUTO, None, false, &pp())
+            .set_ips(
+                "z1",
+                "a.example.com",
+                "A",
+                &ips,
+                false,
+                TTL::AUTO,
+                None,
+                false,
+                &pp(),
+            )
             .await;
         assert_eq!(result, SetResult::Updated);
     }
@@ -1188,7 +1352,17 @@ mod tests {
         let h = handle(&server.uri());
         let ips: Vec<IpAddr> = vec!["1.2.3.4".parse().unwrap()];
         let result = h
-            .set_ips("z1", "a.example.com", "A", &ips, false, TTL::AUTO, None, true, &pp())
+            .set_ips(
+                "z1",
+                "a.example.com",
+                "A",
+                &ips,
+                false,
+                TTL::AUTO,
+                None,
+                true,
+                &pp(),
+            )
             .await;
         assert_eq!(result, SetResult::Updated);
     }
@@ -1258,21 +1432,29 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/zones/z1/dns_records"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
-                dns_record_json("r1", "a.example.com", "1.2.3.4", None),
-                dns_record_json("r2", "a.example.com", "5.6.7.8", None),
-            ])))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
+                    dns_record_json("r1", "a.example.com", "1.2.3.4", None),
+                    dns_record_json("r2", "a.example.com", "5.6.7.8", None),
+                ])),
+            )
             .mount(&server)
             .await;
         Mock::given(method("DELETE"))
             .and(path("/zones/z1/dns_records/r1"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": { "id": "r1" } })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "result": { "id": "r1" } })),
+            )
             .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("DELETE"))
             .and(path("/zones/z1/dns_records/r2"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": { "id": "r2" } })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "result": { "id": "r2" } })),
+            )
             .expect(1)
             .mount(&server)
             .await;
@@ -1344,13 +1526,17 @@ mod tests {
         // list items - empty
         Mock::given(method("GET"))
             .and(path("/accounts/acct1/rules/lists/wl-1/items"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": [] })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": [] })),
+            )
             .mount(&server)
             .await;
         // create items
         Mock::given(method("POST"))
             .and(path("/accounts/acct1/rules/lists/wl-1/items"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": {} })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": {} })),
+            )
             .mount(&server)
             .await;
 
@@ -1360,7 +1546,9 @@ mod tests {
             list_name: "mylist".to_string(),
         };
         let ips: Vec<IpAddr> = vec!["10.0.0.1".parse().unwrap()];
-        let result = h.set_waf_list(&wl, &ips, Some("ddns"), None, false, &pp()).await;
+        let result = h
+            .set_waf_list(&wl, &ips, Some("ddns"), None, false, &pp())
+            .await;
         assert_eq!(result, SetResult::Updated);
     }
 
@@ -1404,7 +1592,9 @@ mod tests {
 
         let h = handle(&server.uri());
         let pp = PP::new(false, true); // quiet
-        let result: Option<CfListResponse<ZoneResult>> = h.api_request(reqwest::Method::GET, "zones", None::<&()>, &pp).await;
+        let result: Option<CfListResponse<ZoneResult>> = h
+            .api_request(reqwest::Method::GET, "zones", None::<&()>, &pp)
+            .await;
         assert!(result.is_none());
     }
 
@@ -1419,7 +1609,9 @@ mod tests {
         let h = handle(&server.uri());
         let pp = PP::new(false, true);
         let body = serde_json::json!({"test": true});
-        let result: Option<CfResponse<serde_json::Value>> = h.api_request(reqwest::Method::POST, "endpoint", Some(&body), &pp).await;
+        let result: Option<CfResponse<serde_json::Value>> = h
+            .api_request(reqwest::Method::POST, "endpoint", Some(&body), &pp)
+            .await;
         assert!(result.is_none());
     }
 
@@ -1434,7 +1626,9 @@ mod tests {
         let h = handle(&server.uri());
         let pp = PP::new(false, true);
         let body = serde_json::json!({"test": true});
-        let result: Option<CfResponse<serde_json::Value>> = h.api_request(reqwest::Method::PUT, "endpoint", Some(&body), &pp).await;
+        let result: Option<CfResponse<serde_json::Value>> = h
+            .api_request(reqwest::Method::PUT, "endpoint", Some(&body), &pp)
+            .await;
         assert!(result.is_none());
     }
 
@@ -1458,23 +1652,30 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/zones/z1/dns_records"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
-                serde_json::json!({
-                    "id": "r1",
-                    "name": "a.example.com",
-                    "content": "1.2.3.4",
-                    "proxied": false,
-                    "ttl": 1,
-                    "comment": null
-                }),
-            ])))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
+                    serde_json::json!({
+                        "id": "r1",
+                        "name": "a.example.com",
+                        "content": "1.2.3.4",
+                        "proxied": false,
+                        "ttl": 1,
+                        "comment": null
+                    }),
+                ])),
+            )
             .mount(&server)
             .await;
         Mock::given(method("PUT"))
             .and(path("/zones/z1/dns_records/r1"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                dns_single_response(dns_record_json("r1", "a.example.com", "1.2.3.4", None)),
-            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_single_response(dns_record_json(
+                    "r1",
+                    "a.example.com",
+                    "1.2.3.4",
+                    None,
+                ))),
+            )
             .expect(1)
             .mount(&server)
             .await;
@@ -1483,7 +1684,17 @@ mod tests {
         let ips: Vec<IpAddr> = vec!["1.2.3.4".parse().unwrap()];
         // proxied=true but record has proxied=false -> should update
         let result = h
-            .set_ips("z1", "a.example.com", "A", &ips, true, TTL::AUTO, None, false, &pp())
+            .set_ips(
+                "z1",
+                "a.example.com",
+                "A",
+                &ips,
+                true,
+                TTL::AUTO,
+                None,
+                false,
+                &pp(),
+            )
             .await;
         assert_eq!(result, SetResult::Updated);
     }
@@ -1495,16 +1706,31 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/zones/z1/dns_records"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
-                dns_record_json("r1", "a.example.com", "9.9.9.9", None),
-            ])))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_list_response(vec![dns_record_json(
+                    "r1",
+                    "a.example.com",
+                    "9.9.9.9",
+                    None,
+                )])),
+            )
             .mount(&server)
             .await;
 
         let h = handle(&server.uri());
         let ips: Vec<IpAddr> = vec!["1.2.3.4".parse().unwrap()];
         let result = h
-            .set_ips("z1", "a.example.com", "A", &ips, false, TTL::AUTO, None, true, &pp())
+            .set_ips(
+                "z1",
+                "a.example.com",
+                "A",
+                &ips,
+                false,
+                TTL::AUTO,
+                None,
+                true,
+                &pp(),
+            )
             .await;
         assert_eq!(result, SetResult::Updated);
     }
@@ -1523,7 +1749,17 @@ mod tests {
         let h = handle(&server.uri());
         let ips: Vec<IpAddr> = vec![];
         let result = h
-            .set_ips("z1", "a.example.com", "A", &ips, false, TTL::AUTO, None, false, &pp())
+            .set_ips(
+                "z1",
+                "a.example.com",
+                "A",
+                &ips,
+                false,
+                TTL::AUTO,
+                None,
+                false,
+                &pp(),
+            )
             .await;
         assert_eq!(result, SetResult::Noop);
     }
@@ -1535,16 +1771,31 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/zones/z1/dns_records"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(dns_list_response(vec![
-                dns_record_json("r1", "a.example.com", "1.2.3.4", None),
-            ])))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(dns_list_response(vec![dns_record_json(
+                    "r1",
+                    "a.example.com",
+                    "1.2.3.4",
+                    None,
+                )])),
+            )
             .mount(&server)
             .await;
 
         let h = handle(&server.uri());
         let ips: Vec<IpAddr> = vec![];
         let result = h
-            .set_ips("z1", "a.example.com", "A", &ips, false, TTL::AUTO, None, true, &pp())
+            .set_ips(
+                "z1",
+                "a.example.com",
+                "A",
+                &ips,
+                false,
+                TTL::AUTO,
+                None,
+                true,
+                &pp(),
+            )
             .await;
         assert_eq!(result, SetResult::Updated);
     }
@@ -1659,7 +1910,9 @@ mod tests {
             .await;
         Mock::given(method("DELETE"))
             .and(path("/accounts/acct1/rules/lists/wl-1/items"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": {} })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": {} })),
+            )
             .expect(1)
             .mount(&server)
             .await;
@@ -1716,7 +1969,9 @@ mod tests {
         // delete items
         Mock::given(method("DELETE"))
             .and(path("/accounts/acct1/rules/lists/wl-1/items"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": {} })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "result": {} })),
+            )
             .mount(&server)
             .await;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -538,7 +538,7 @@ pub fn load_env_config(ppfmt: &PP) -> Result<AppConfig, String> {
     let reject_cloudflare_ips = getenv_bool("REJECT_CLOUDFLARE_IPS", true);
 
     // Validate: must have at least one update target
-    if domains.is_empty() && waf_lists.is_empty() {
+    if domains.is_empty() && docker_host.is_none() && waf_lists.is_empty() {
         return Err(
             "No update targets configured. Set DOMAINS, IP4_DOMAINS, IP6_DOMAINS, or WAF_LISTS."
                 .to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -540,7 +540,7 @@ pub fn load_env_config(ppfmt: &PP) -> Result<AppConfig, String> {
     // Validate: must have at least one update target
     if domains.is_empty() && docker_host.is_none() && waf_lists.is_empty() {
         return Err(
-            "No update targets configured. Set DOMAINS, IP4_DOMAINS, IP6_DOMAINS, or WAF_LISTS."
+            "No update targets configured. Set DOMAINS, IP4_DOMAINS, IP6_DOMAINS, WAF_LISTS, or DOCKER_HOST."
                 .to_string(),
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,7 @@ pub struct AppConfig {
     pub auth: Auth,
     pub providers: HashMap<IpType, ProviderType>,
     pub domains: HashMap<IpType, Vec<String>>, // FQDN domains by IP type
+    pub docker_host: Option<String>,
     pub waf_lists: Vec<WAFList>,
     pub update_cron: CronSchedule,
     pub update_on_start: bool,
@@ -446,6 +447,7 @@ fn legacy_to_app_config(legacy: LegacyConfig, dry_run: bool, repeat: bool) -> Re
         auth,
         providers,
         domains: HashMap::new(),
+        docker_host: None,
         waf_lists: Vec::new(),
         update_cron: schedule,
         update_on_start: true,
@@ -501,6 +503,7 @@ pub fn load_env_config(ppfmt: &PP) -> Result<AppConfig, String> {
 
     let providers = read_providers_from_env(ppfmt)?;
     let domains = read_domains_from_env(ppfmt);
+    let docker_host = getenv("DOCKER_HOST");
     let waf_lists = read_waf_lists_from_env(ppfmt);
     let update_cron = read_cron_from_env(ppfmt)?;
     let update_on_start = getenv_bool("UPDATE_ON_START", true);
@@ -570,6 +573,7 @@ pub fn load_env_config(ppfmt: &PP) -> Result<AppConfig, String> {
         auth,
         providers,
         domains,
+        docker_host,
         waf_lists,
         update_cron,
         update_on_start,
@@ -1317,6 +1321,7 @@ mod tests {
             auth: Auth::Token(String::new()),
             providers: HashMap::new(),
             domains: HashMap::new(),
+            docker_host: None,
             waf_lists: Vec::new(),
             update_cron: CronSchedule::Once,
             update_on_start: true,
@@ -1352,6 +1357,7 @@ mod tests {
             auth: Auth::Token("tok".to_string()),
             providers: HashMap::new(),
             domains,
+            docker_host: None,
             waf_lists: Vec::new(),
             update_cron: CronSchedule::Every(Duration::from_secs(300)),
             update_on_start: true,
@@ -2005,6 +2011,7 @@ mod tests {
             auth: Auth::Token("tok".to_string()),
             providers: HashMap::new(),
             domains: HashMap::new(),
+            docker_host: None,
             waf_lists: vec![waf_list],
             update_cron: CronSchedule::Every(Duration::from_secs(300)),
             update_on_start: true,
@@ -2042,6 +2049,7 @@ mod tests {
             auth: Auth::Token("tok".to_string()),
             providers,
             domains,
+            docker_host: None,
             waf_lists: Vec::new(),
             update_cron: CronSchedule::Every(Duration::from_secs(600)),
             update_on_start: true,
@@ -2076,6 +2084,7 @@ mod tests {
             auth: Auth::Token("tok".to_string()),
             providers: HashMap::new(),
             domains,
+            docker_host: None,
             waf_lists: Vec::new(),
             update_cron: CronSchedule::Once,
             update_on_start: true,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,0 +1,111 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use bollard::{errors::Error, query_parameters::ListContainersOptionsBuilder, Docker};
+use tokio::{sync::watch::Sender, time::sleep};
+
+use crate::{
+    pp::{self, PP},
+    provider::IpType,
+};
+
+pub async fn spawn_docker_domain_scanner(
+    static_domains: HashMap<IpType, Vec<String>>,
+    docker_sock: String,
+    domains_tx: &mut Sender<HashMap<IpType, Vec<String>>>,
+    running: Arc<AtomicBool>,
+    ppfmt: &PP,
+) -> Result<(), Error> {
+    let docker = Docker::connect_with_host(docker_sock.as_str())?;
+
+    let mut docker_domains = scan_and_publish_once(
+        &docker,
+        &static_domains,
+        HashSet::default(),
+        &mut domains_tx.clone(),
+    )
+    .await?;
+
+    let domains_tx = domains_tx.clone();
+    let ppfmt_owned = ppfmt.clone();
+
+    tokio::spawn(async move {
+        while running.load(Ordering::SeqCst) {
+            docker_domains = match scan_and_publish_once(
+                &docker,
+                &static_domains,
+                docker_domains.clone(),
+                &mut domains_tx.clone(),
+            )
+            .await
+            {
+                Ok(dd) => dd,
+                Err(e) => {
+                    ppfmt_owned.errorf(
+                        pp::EMOJI_ERROR,
+                        &format!("DOCKER unable to scan: {}", e.to_string()),
+                    );
+
+                    HashSet::default()
+                }
+            };
+
+            sleep(Duration::from_secs(5)).await;
+        }
+    });
+
+    return Ok(());
+}
+
+async fn scan_and_publish_once(
+    docker: &Docker,
+    static_domains: &HashMap<IpType, Vec<String>>,
+    docker_domains: HashSet<String>,
+    domains_tx: &mut Sender<HashMap<IpType, Vec<String>>>,
+) -> Result<HashSet<String>, Error> {
+    let list_options = ListContainersOptionsBuilder::default()
+        .all(true)
+        .filters(&HashMap::from([(
+            "status",
+            vec!["created", "restarting", "running"],
+        )]))
+        .build();
+
+    let list = docker.list_containers(Some(list_options)).await?;
+
+    let new_docker_domains: HashSet<String> = list
+        .iter()
+        .filter_map(|c| {
+            c.labels
+                .as_ref()
+                .and_then(|labels| labels.get("ddns.domain"))
+        })
+        .cloned()
+        .collect();
+
+    if docker_domains == new_docker_domains {
+        return Ok(docker_domains);
+    }
+
+    let mut new_domains = static_domains.clone();
+
+    new_domains
+        .entry(IpType::V4)
+        .or_default()
+        .extend(new_docker_domains.clone());
+
+    new_domains
+        .entry(IpType::V6)
+        .or_default()
+        .extend(new_docker_domains.clone());
+
+    domains_tx.send_replace(new_domains);
+
+    return Ok(new_docker_domains);
+}

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -8,12 +8,88 @@ use std::{
 };
 
 use bollard::{errors::Error, query_parameters::ListContainersOptionsBuilder, Docker};
-use tokio::{sync::watch::Sender, time::sleep};
+use tokio::{
+    sync::watch::{Receiver, Sender},
+    time::sleep,
+};
 
 use crate::{
+    cloudflare::CloudflareHandle,
+    config::AppConfig,
+    notifier::{CompositeNotifier, Message},
     pp::{self, PP},
     provider::IpType,
 };
+
+pub async fn spawn_domain_cleanup(
+    config: &AppConfig,
+    domains_rx: &mut Receiver<HashMap<IpType, Vec<String>>>,
+    running: Arc<AtomicBool>,
+    ppfmt: &PP,
+    handle: &CloudflareHandle,
+    notifier: &CompositeNotifier,
+) -> Result<(), Error> {
+    if !config.delete_on_stop || config.legacy_mode {
+        return Ok(());
+    }
+
+    let ppfmt_owned = ppfmt.clone();
+    let handle_owned = handle.clone();
+    let notifier_owned = notifier.clone();
+    let mut domains_rx = domains_rx.clone();
+
+    tokio::spawn(async move {
+        let mut current_domains = domains_rx.borrow_and_update().clone();
+        while running.load(Ordering::SeqCst) {
+            loop {
+                if !running.load(Ordering::SeqCst) {
+                    return;
+                }
+
+                match domains_rx.has_changed() {
+                    Ok(true) => break, // Changed
+                    Ok(false) => {}    // No change yet
+                    Err(_) => return,  // channel closed
+                }
+
+                sleep(Duration::from_secs(1)).await;
+            }
+
+            let mut messages = Vec::new();
+            let new_domains = domains_rx.borrow_and_update().clone();
+
+            for (ip_type, old_domains_list) in current_domains.iter() {
+                let record_type = ip_type.record_type();
+                let new_domains_list = new_domains.get(ip_type).unwrap_or(old_domains_list);
+                let domains_diff = old_domains_list
+                    .into_iter()
+                    .filter(|d| !new_domains_list.contains(d));
+
+                for domain_str in domains_diff {
+                    // Use the owned handle
+                    if let Some(zone_id) = handle_owned
+                        .zone_id_of_domain(domain_str, &ppfmt_owned)
+                        .await
+                    {
+                        handle_owned
+                            .final_delete(&zone_id, domain_str, record_type, &ppfmt_owned)
+                            .await;
+                        messages.push(Message::new_ok(&format!(
+                            "Deleted records for {domain_str}"
+                        )));
+                    }
+                }
+            }
+
+            let msg = Message::merge(messages);
+            notifier_owned.send(&msg).await;
+
+            current_domains = new_domains;
+        }
+    });
+
+    return Ok(());
+}
 
 pub async fn spawn_docker_domain_scanner(
     static_domains: HashMap<IpType, Vec<String>>,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -52,7 +52,7 @@ pub async fn spawn_docker_domain_scanner(
                         &format!("DOCKER unable to scan: {}", e.to_string()),
                     );
 
-                    HashSet::default()
+                    docker_domains
                 }
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,16 @@ async fn main() {
     // Start heartbeat
     heartbeat.start().await;
 
+    let _ = docker::spawn_domain_cleanup(
+        &app_config,
+        &mut domains_rx.clone(),
+        running.clone(),
+        &ppfmt,
+        &handle,
+        &notifier,
+    )
+    .await;
+
     let mut cf_cache = cf_ip_filter::CachedCloudflareFilter::new();
     let detection_client = Client::builder()
         .timeout(app_config.detection_timeout)
@@ -195,9 +205,7 @@ async fn main() {
     }
 
     // Exit heartbeat
-    heartbeat
-        .exit(&Message::new_ok("Shutting down"))
-        .await;
+    heartbeat.exit(&Message::new_ok("Shutting down")).await;
 }
 
 async fn run_legacy_mode(
@@ -233,11 +241,11 @@ async fn run_legacy_mode(
             (false, false) => println!("Both IPv4 and IPv6 are disabled"),
         }
 
-        while running.load(Ordering::SeqCst) {
-            let domains = domains_chan.borrow_and_update().clone();
+        if config.update_on_start {
+            let domains = domains_chan.borrow_and_update();
             updater::update_once(
                 config,
-                domains,
+                &domains,
                 handle,
                 notifier,
                 heartbeat,
@@ -247,7 +255,9 @@ async fn run_legacy_mode(
                 detection_client,
             )
             .await;
+        }
 
+        while running.load(Ordering::SeqCst) {
             for _ in 0..legacy.ttl {
                 if !running.load(Ordering::SeqCst) {
                     break;
@@ -261,12 +271,26 @@ async fn run_legacy_mode(
 
                 sleep(Duration::from_secs(1)).await;
             }
+
+            let domains = domains_chan.borrow_and_update();
+            updater::update_once(
+                config,
+                &domains,
+                handle,
+                notifier,
+                heartbeat,
+                cf_cache,
+                ppfmt,
+                &mut noop_reported,
+                detection_client,
+            )
+            .await;
         }
     } else {
-        let domains = domains_chan.borrow_and_update().clone();
+        let domains = domains_chan.borrow_and_update();
         updater::update_once(
             config,
-            domains,
+            &domains,
             handle,
             notifier,
             heartbeat,
@@ -295,10 +319,10 @@ async fn run_env_mode(
     match &config.update_cron {
         CronSchedule::Once => {
             if config.update_on_start {
-                let domains = domains_chan.borrow_and_update().clone();
+                let domains = domains_chan.borrow_and_update();
                 updater::update_once(
                     config,
-                    domains,
+                    &domains,
                     handle,
                     notifier,
                     heartbeat,
@@ -323,10 +347,10 @@ async fn run_env_mode(
 
             // Update on start if configured
             if config.update_on_start {
-                let domains = domains_chan.borrow_and_update().clone();
+                let domains = domains_chan.borrow_and_update();
                 updater::update_once(
                     config,
-                    domains,
+                    &domains,
                     handle,
                     notifier,
                     heartbeat,
@@ -375,10 +399,10 @@ async fn run_env_mode(
                     sleep(std::time::Duration::from_secs(jitter_secs)).await;
                 }
 
-                let domains = domains_chan.borrow_and_update().clone();
+                let domains = domains_chan.borrow_and_update();
                 updater::update_once(
                     config,
-                    domains,
+                    &domains,
                     handle,
                     notifier,
                     heartbeat,
@@ -446,8 +470,8 @@ pub(crate) fn test_client() -> reqwest::Client {
 #[cfg(test)]
 mod tests {
     use crate::config::{
-        LegacyAuthentication, LegacyCloudflareEntry, LegacyConfig, LegacySubdomainEntry,
-        parse_legacy_config,
+        parse_legacy_config, LegacyAuthentication, LegacyCloudflareEntry, LegacyConfig,
+        LegacySubdomainEntry,
     };
     use crate::provider::parse_trace_ip;
     use reqwest::Client;
@@ -693,8 +717,7 @@ mod tests {
                             println!("[DRY RUN] Would add new record {fqdn} -> {ip}");
                         } else {
                             println!("Adding new record {fqdn} -> {ip}");
-                            let create_endpoint =
-                                format!("zones/{}/dns_records", entry.zone_id);
+                            let create_endpoint = format!("zones/{}/dns_records", entry.zone_id);
                             let _: Option<serde_json::Value> = self
                                 .cf_api(
                                     &create_endpoint,
@@ -823,8 +846,15 @@ mod tests {
 
         let ddns = TestDdnsClient::new(&mock_server.uri());
         let config = test_config(zone_id);
-        ddns.commit_record("198.51.100.7", "A", &config.cloudflare, 300, false, &mut std::collections::HashSet::new())
-            .await;
+        ddns.commit_record(
+            "198.51.100.7",
+            "A",
+            &config.cloudflare,
+            300,
+            false,
+            &mut std::collections::HashSet::new(),
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -872,8 +902,15 @@ mod tests {
 
         let ddns = TestDdnsClient::new(&mock_server.uri());
         let config = test_config(zone_id);
-        ddns.commit_record("198.51.100.7", "A", &config.cloudflare, 300, false, &mut std::collections::HashSet::new())
-            .await;
+        ddns.commit_record(
+            "198.51.100.7",
+            "A",
+            &config.cloudflare,
+            300,
+            false,
+            &mut std::collections::HashSet::new(),
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -915,8 +952,15 @@ mod tests {
 
         let ddns = TestDdnsClient::new(&mock_server.uri());
         let config = test_config(zone_id);
-        ddns.commit_record("198.51.100.7", "A", &config.cloudflare, 300, false, &mut std::collections::HashSet::new())
-            .await;
+        ddns.commit_record(
+            "198.51.100.7",
+            "A",
+            &config.cloudflare,
+            300,
+            false,
+            &mut std::collections::HashSet::new(),
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -949,8 +993,15 @@ mod tests {
 
         let ddns = TestDdnsClient::new(&mock_server.uri()).dry_run();
         let config = test_config(zone_id);
-        ddns.commit_record("198.51.100.7", "A", &config.cloudflare, 300, false, &mut std::collections::HashSet::new())
-            .await;
+        ddns.commit_record(
+            "198.51.100.7",
+            "A",
+            &config.cloudflare,
+            300,
+            false,
+            &mut std::collections::HashSet::new(),
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1006,8 +1057,15 @@ mod tests {
             ip4_provider: None,
             ip6_provider: None,
         };
-        ddns.commit_record("198.51.100.7", "A", &config.cloudflare, 300, true, &mut std::collections::HashSet::new())
-            .await;
+        ddns.commit_record(
+            "198.51.100.7",
+            "A",
+            &config.cloudflare,
+            300,
+            true,
+            &mut std::collections::HashSet::new(),
+        )
+        .await;
     }
 
     // --- jitter_duration tests ---
@@ -1131,7 +1189,14 @@ mod tests {
             ip6_provider: None,
         };
 
-        ddns.commit_record("203.0.113.99", "A", &config.cloudflare, 300, false, &mut std::collections::HashSet::new())
-            .await;
+        ddns.commit_record(
+            "203.0.113.99",
+            "A",
+            &config.cloudflare,
+            300,
+            false,
+            &mut std::collections::HashSet::new(),
+        )
+        .await;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cf_ip_filter;
 mod cloudflare;
 mod config;
+mod docker;
 mod domain;
 mod notifier;
 mod pp;
@@ -120,6 +121,28 @@ async fn main() {
         r.store(false, Ordering::SeqCst);
     });
 
+    if let Some(docker_sock) = app_config.docker_host.clone() {
+        match docker::spawn_docker_domain_scanner(
+            static_domains,
+            docker_sock,
+            &mut domains_tx.clone(),
+            running.clone(),
+            &ppfmt,
+        )
+        .await
+        {
+            Ok(_) => {}
+            Err(e) => {
+                ppfmt.errorf(
+                    pp::EMOJI_ERROR,
+                    &format!("DOCKER unable to scan: {}", e.to_string()),
+                );
+
+                return;
+            }
+        }
+    }
+
     // Start heartbeat
     heartbeat.start().await;
 
@@ -132,9 +155,28 @@ async fn main() {
     if app_config.legacy_mode {
         // --- Legacy mode (original cloudflare-ddns behavior) ---
         run_legacy_mode(&app_config, &handle, &notifier, &heartbeat, &ppfmt, running, &mut cf_cache, &detection_client).await;
+            &mut domains_rx.clone(),
+            &handle,
+            &notifier,
+            &heartbeat,
+            &ppfmt,
+            running,
+            &mut cf_cache,
+            &detection_client,
+        )
+        .await;
     } else {
         // --- Env var mode (cf-ddns behavior) ---
-        run_env_mode(&app_config, &handle, &notifier, &heartbeat, &ppfmt, running, &mut cf_cache, &detection_client).await;
+            &mut domains_rx.clone(),
+            &handle,
+            &notifier,
+            &heartbeat,
+            &ppfmt,
+            running,
+            &mut cf_cache,
+            &detection_client,
+        )
+        .await;
     }
 
     // On shutdown: delete records if configured
@@ -183,16 +225,42 @@ async fn run_legacy_mode(
 
         while running.load(Ordering::SeqCst) {
             updater::update_once(config, handle, notifier, heartbeat, cf_cache, ppfmt, &mut noop_reported, detection_client).await;
+                config,
+                domains,
+                handle,
+                notifier,
+                heartbeat,
+                cf_cache,
+                ppfmt,
+                &mut noop_reported,
+                detection_client,
+            )
+            .await;
 
             for _ in 0..legacy.ttl {
                 if !running.load(Ordering::SeqCst) {
                     break;
                 }
+                    Ok(false) => {}    // No change yet
+                    Err(_) => return,  // channel closed
+                }
+
                 sleep(Duration::from_secs(1)).await;
             }
         }
     } else {
         updater::update_once(config, handle, notifier, heartbeat, cf_cache, ppfmt, &mut noop_reported, detection_client).await;
+            config,
+            domains,
+            handle,
+            notifier,
+            heartbeat,
+            cf_cache,
+            ppfmt,
+            &mut noop_reported,
+            detection_client,
+        )
+        .await;
     }
 }
 
@@ -212,6 +280,17 @@ async fn run_env_mode(
         CronSchedule::Once => {
             if config.update_on_start {
                 updater::update_once(config, handle, notifier, heartbeat, cf_cache, ppfmt, &mut noop_reported, detection_client).await;
+                    config,
+                    domains,
+                    handle,
+                    notifier,
+                    heartbeat,
+                    cf_cache,
+                    ppfmt,
+                    &mut noop_reported,
+                    detection_client,
+                )
+                .await;
             }
         }
         schedule => {
@@ -228,6 +307,17 @@ async fn run_env_mode(
             // Update on start if configured
             if config.update_on_start {
                 updater::update_once(config, handle, notifier, heartbeat, cf_cache, ppfmt, &mut noop_reported, detection_client).await;
+                    config,
+                    domains,
+                    handle,
+                    notifier,
+                    heartbeat,
+                    cf_cache,
+                    ppfmt,
+                    &mut noop_reported,
+                    detection_client,
+                )
+                .await;
             }
 
             // Main loop
@@ -245,6 +335,10 @@ async fn run_env_mode(
                     if !running.load(Ordering::SeqCst) {
                         return;
                     }
+                        Ok(false) => {}    // No change yet
+                        Err(_) => return,  // channel closed
+                    }
+
                     sleep(Duration::from_secs(1)).await;
                 }
 
@@ -261,6 +355,17 @@ async fn run_env_mode(
                 }
 
                 updater::update_once(config, handle, notifier, heartbeat, cf_cache, ppfmt, &mut noop_reported, detection_client).await;
+                    config,
+                    domains,
+                    handle,
+                    notifier,
+                    heartbeat,
+                    cf_cache,
+                    ppfmt,
+                    &mut noop_reported,
+                    detection_client,
+                )
+                .await;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,15 @@ use crate::cloudflare::{Auth, CloudflareHandle};
 use crate::config::{AppConfig, CronSchedule};
 use crate::notifier::{CompositeNotifier, Heartbeat, Message};
 use crate::pp::PP;
-use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use crate::provider::IpType;
 use rand::RngExt;
 use reqwest::Client;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use tokio::signal;
+use tokio::sync::watch;
+use tokio::sync::watch::Receiver;
 use tokio::time::{sleep, Duration};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -121,6 +124,9 @@ async fn main() {
         r.store(false, Ordering::SeqCst);
     });
 
+    let static_domains = app_config.domains.clone();
+    let (domains_tx, domains_rx) = watch::channel(static_domains.clone());
+
     if let Some(docker_sock) = app_config.docker_host.clone() {
         match docker::spawn_docker_domain_scanner(
             static_domains,
@@ -154,7 +160,8 @@ async fn main() {
 
     if app_config.legacy_mode {
         // --- Legacy mode (original cloudflare-ddns behavior) ---
-        run_legacy_mode(&app_config, &handle, &notifier, &heartbeat, &ppfmt, running, &mut cf_cache, &detection_client).await;
+        run_legacy_mode(
+            &app_config,
             &mut domains_rx.clone(),
             &handle,
             &notifier,
@@ -167,6 +174,8 @@ async fn main() {
         .await;
     } else {
         // --- Env var mode (cf-ddns behavior) ---
+        run_env_mode(
+            &app_config,
             &mut domains_rx.clone(),
             &handle,
             &notifier,
@@ -193,6 +202,7 @@ async fn main() {
 
 async fn run_legacy_mode(
     config: &AppConfig,
+    domains_chan: &mut Receiver<HashMap<IpType, Vec<String>>>,
     handle: &CloudflareHandle,
     notifier: &CompositeNotifier,
     heartbeat: &Heartbeat,
@@ -224,7 +234,8 @@ async fn run_legacy_mode(
         }
 
         while running.load(Ordering::SeqCst) {
-            updater::update_once(config, handle, notifier, heartbeat, cf_cache, ppfmt, &mut noop_reported, detection_client).await;
+            let domains = domains_chan.borrow_and_update().clone();
+            updater::update_once(
                 config,
                 domains,
                 handle,
@@ -241,6 +252,9 @@ async fn run_legacy_mode(
                 if !running.load(Ordering::SeqCst) {
                     break;
                 }
+
+                match domains_chan.has_changed() {
+                    Ok(true) => break, // Changed
                     Ok(false) => {}    // No change yet
                     Err(_) => return,  // channel closed
                 }
@@ -249,7 +263,8 @@ async fn run_legacy_mode(
             }
         }
     } else {
-        updater::update_once(config, handle, notifier, heartbeat, cf_cache, ppfmt, &mut noop_reported, detection_client).await;
+        let domains = domains_chan.borrow_and_update().clone();
+        updater::update_once(
             config,
             domains,
             handle,
@@ -266,6 +281,7 @@ async fn run_legacy_mode(
 
 async fn run_env_mode(
     config: &AppConfig,
+    domains_chan: &mut Receiver<HashMap<IpType, Vec<String>>>,
     handle: &CloudflareHandle,
     notifier: &CompositeNotifier,
     heartbeat: &Heartbeat,
@@ -279,7 +295,8 @@ async fn run_env_mode(
     match &config.update_cron {
         CronSchedule::Once => {
             if config.update_on_start {
-                updater::update_once(config, handle, notifier, heartbeat, cf_cache, ppfmt, &mut noop_reported, detection_client).await;
+                let domains = domains_chan.borrow_and_update().clone();
+                updater::update_once(
                     config,
                     domains,
                     handle,
@@ -306,7 +323,8 @@ async fn run_env_mode(
 
             // Update on start if configured
             if config.update_on_start {
-                updater::update_once(config, handle, notifier, heartbeat, cf_cache, ppfmt, &mut noop_reported, detection_client).await;
+                let domains = domains_chan.borrow_and_update().clone();
+                updater::update_once(
                     config,
                     domains,
                     handle,
@@ -335,6 +353,9 @@ async fn run_env_mode(
                     if !running.load(Ordering::SeqCst) {
                         return;
                     }
+
+                    match domains_chan.has_changed() {
+                        Ok(true) => break, // Changed
                         Ok(false) => {}    // No change yet
                         Err(_) => return,  // channel closed
                     }
@@ -354,7 +375,8 @@ async fn run_env_mode(
                     sleep(std::time::Duration::from_secs(jitter_secs)).await;
                 }
 
-                updater::update_once(config, handle, notifier, heartbeat, cf_cache, ppfmt, &mut noop_reported, detection_client).await;
+                let domains = domains_chan.borrow_and_update().clone();
+                updater::update_once(
                     config,
                     domains,
                     handle,

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -48,16 +48,37 @@ impl Message {
 
 // --- Composite Notifier ---
 
+#[derive(Clone)]
 pub struct CompositeNotifier {
     notifiers: Vec<Box<dyn NotifierDyn>>,
 }
 
 // Object-safe version of Notifier
-pub trait NotifierDyn: Send + Sync {
+pub trait NotifierDyn: CloneBox + Send + Sync {
     fn send_dyn<'a>(
         &'a self,
         msg: &'a Message,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + 'a>>;
+}
+
+// Helper trait to perform the actual cloning into a Box
+pub trait CloneBox {
+    fn clone_box(&self) -> Box<dyn NotifierDyn>;
+}
+
+impl<T> CloneBox for T
+where
+    T: NotifierDyn + Clone + 'static,
+{
+    fn clone_box(&self) -> Box<dyn NotifierDyn> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn NotifierDyn> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
 }
 
 impl CompositeNotifier {
@@ -76,18 +97,20 @@ impl CompositeNotifier {
 }
 
 // --- Shoutrrr Notifier ---
-
+#[derive(Clone)]
 pub struct ShoutrrrNotifier {
     client: Client,
     urls: Vec<ShoutrrrService>,
 }
 
+#[derive(Clone)]
 struct ShoutrrrService {
     original_url: String,
     service_type: ShoutrrrServiceType,
     webhook_url: String,
 }
 
+#[derive(Clone)]
 enum ShoutrrrServiceType {
     Generic,
     Discord,
@@ -147,8 +170,12 @@ impl ShoutrrrNotifier {
         let mut all_ok = true;
         for service in &self.urls {
             let ok = match &service.service_type {
-                ShoutrrrServiceType::Generic => self.send_generic(&service.webhook_url, &text).await,
-                ShoutrrrServiceType::Discord => self.send_discord(&service.webhook_url, &text).await,
+                ShoutrrrServiceType::Generic => {
+                    self.send_generic(&service.webhook_url, &text).await
+                }
+                ShoutrrrServiceType::Discord => {
+                    self.send_discord(&service.webhook_url, &text).await
+                }
                 ShoutrrrServiceType::Slack => self.send_slack(&service.webhook_url, &text).await,
                 ShoutrrrServiceType::Telegram => {
                     self.send_telegram(&service.webhook_url, &text).await
@@ -157,7 +184,9 @@ impl ShoutrrrNotifier {
                 ShoutrrrServiceType::Pushover => {
                     self.send_pushover(&service.webhook_url, &text).await
                 }
-                ShoutrrrServiceType::Other(_) => self.send_generic(&service.webhook_url, &text).await,
+                ShoutrrrServiceType::Other(_) => {
+                    self.send_generic(&service.webhook_url, &text).await
+                }
             };
             if !ok {
                 ppfmt.warningf(
@@ -498,7 +527,6 @@ fn parse_shoutrrr_url(url_str: &str) -> Result<ShoutrrrService, String> {
 }
 
 // --- Heartbeat ---
-
 pub struct Heartbeat {
     monitors: Vec<Box<dyn HeartbeatMonitor>>,
 }
@@ -508,9 +536,7 @@ pub trait HeartbeatMonitor: Send + Sync {
         &'a self,
         msg: &'a Message,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + 'a>>;
-    fn start(
-        &self,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>>;
+    fn start(&self) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>>;
     fn exit<'a>(
         &'a self,
         msg: &'a Message,
@@ -594,9 +620,7 @@ impl HeartbeatMonitor for HealthchecksMonitor {
         })
     }
 
-    fn start(
-        &self,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
+    fn start(&self) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
         Box::pin(async move { self.send_ping("start", None).await })
     }
 
@@ -656,9 +680,7 @@ impl HeartbeatMonitor for UptimeKumaMonitor {
         })
     }
 
-    fn start(
-        &self,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
+    fn start(&self) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
         Box::pin(async move {
             let url = format!("{}?status=up&msg=Starting", self.base_url);
             self.client
@@ -812,16 +834,12 @@ mod tests {
 
     #[test]
     fn test_parse_telegram() {
-        let result =
-            parse_shoutrrr_url("telegram://bottoken123@telegram?chats=12345").unwrap();
+        let result = parse_shoutrrr_url("telegram://bottoken123@telegram?chats=12345").unwrap();
         assert_eq!(
             result.webhook_url,
             "https://api.telegram.org/botbottoken123/sendMessage?chat_id=12345"
         );
-        assert!(matches!(
-            result.service_type,
-            ShoutrrrServiceType::Telegram
-        ));
+        assert!(matches!(result.service_type, ShoutrrrServiceType::Telegram));
     }
 
     #[test]
@@ -844,9 +862,10 @@ mod tests {
     #[test]
     fn test_parse_gotify_token_query_param() {
         // Older "gotify://host?token=..." form (issue #262).
-        let result =
-            parse_shoutrrr_url("gotify://192.168.178.222:9090?token=AtE2tUGQig67b0J&disabletls=yes")
-                .unwrap();
+        let result = parse_shoutrrr_url(
+            "gotify://192.168.178.222:9090?token=AtE2tUGQig67b0J&disabletls=yes",
+        )
+        .unwrap();
         assert_eq!(
             result.webhook_url,
             "http://192.168.178.222:9090/message?token=AtE2tUGQig67b0J"
@@ -855,8 +874,7 @@ mod tests {
 
     #[test]
     fn test_parse_gotify_disabletls_switches_to_http() {
-        let result =
-            parse_shoutrrr_url("gotify://10.0.0.1:8080/TOKEN123?disabletls=yes").unwrap();
+        let result = parse_shoutrrr_url("gotify://10.0.0.1:8080/TOKEN123?disabletls=yes").unwrap();
         assert_eq!(
             result.webhook_url,
             "http://10.0.0.1:8080/message?token=TOKEN123"
@@ -887,16 +905,14 @@ mod tests {
 
     #[test]
     fn test_parse_generic_plus_https() {
-        let result =
-            parse_shoutrrr_url("generic+https://example.com/webhook").unwrap();
+        let result = parse_shoutrrr_url("generic+https://example.com/webhook").unwrap();
         assert_eq!(result.webhook_url, "https://example.com/webhook");
         assert!(matches!(result.service_type, ShoutrrrServiceType::Generic));
     }
 
     #[test]
     fn test_parse_generic_plus_http() {
-        let result =
-            parse_shoutrrr_url("generic+http://example.com/webhook").unwrap();
+        let result = parse_shoutrrr_url("generic+http://example.com/webhook").unwrap();
         assert_eq!(result.webhook_url, "http://example.com/webhook");
         assert!(matches!(result.service_type, ShoutrrrServiceType::Generic));
     }
@@ -908,18 +924,14 @@ mod tests {
             result.webhook_url,
             "https://api.pushover.net/1/messages.json?token=apitoken&user=userkey"
         );
-        assert!(matches!(
-            result.service_type,
-            ShoutrrrServiceType::Pushover
-        ));
+        assert!(matches!(result.service_type, ShoutrrrServiceType::Pushover));
     }
 
     #[test]
     fn test_parse_pushover_shoutrrr_canonical_form() {
         // Shoutrrr's canonical URL has a literal "shoutrrr:" username.
         // Issue #258: parser must strip this prefix or Pushover rejects the token.
-        let result =
-            parse_shoutrrr_url("pushover://shoutrrr:apitoken@userkey").unwrap();
+        let result = parse_shoutrrr_url("pushover://shoutrrr:apitoken@userkey").unwrap();
         assert_eq!(
             result.webhook_url,
             "https://api.pushover.net/1/messages.json?token=apitoken&user=userkey"
@@ -930,8 +942,7 @@ mod tests {
     fn test_parse_pushover_strips_query_params() {
         // Optional shoutrrr query params (devices, priority) should not break parsing.
         let result =
-            parse_shoutrrr_url("pushover://shoutrrr:tok@user/?devices=phone&priority=1")
-                .unwrap();
+            parse_shoutrrr_url("pushover://shoutrrr:tok@user/?devices=phone&priority=1").unwrap();
         assert_eq!(
             result.webhook_url,
             "https://api.pushover.net/1/messages.json?token=tok&user=user"
@@ -952,16 +963,14 @@ mod tests {
 
     #[test]
     fn test_parse_plain_https_url() {
-        let result =
-            parse_shoutrrr_url("https://hooks.example.com/notify").unwrap();
+        let result = parse_shoutrrr_url("https://hooks.example.com/notify").unwrap();
         assert_eq!(result.webhook_url, "https://hooks.example.com/notify");
         assert!(matches!(result.service_type, ShoutrrrServiceType::Generic));
     }
 
     #[test]
     fn test_parse_plain_http_url() {
-        let result =
-            parse_shoutrrr_url("http://hooks.example.com/notify").unwrap();
+        let result = parse_shoutrrr_url("http://hooks.example.com/notify").unwrap();
         assert_eq!(result.webhook_url, "http://hooks.example.com/notify");
         assert!(matches!(result.service_type, ShoutrrrServiceType::Generic));
     }
@@ -1243,7 +1252,10 @@ mod tests {
             client: crate::test_client(),
             urls: vec![],
         };
-        let msg = Message { lines: Vec::new(), ok: true };
+        let msg = Message {
+            lines: Vec::new(),
+            ok: true,
+        };
         let pp = PP::default_pp();
         // Empty message should return true immediately
         let result = notifier.send(&msg, &pp).await;
@@ -1254,14 +1266,21 @@ mod tests {
 
     #[test]
     fn test_shoutrrr_notifier_new_valid() {
-        let urls = vec!["discord://token@id".to_string(), "slack://a/b/c".to_string()];
+        let urls = vec![
+            "discord://token@id".to_string(),
+            "slack://a/b/c".to_string(),
+        ];
         let notifier = ShoutrrrNotifier::new(&urls).unwrap();
         assert_eq!(notifier.urls.len(), 2);
     }
 
     #[test]
     fn test_shoutrrr_notifier_new_skips_empty() {
-        let urls = vec!["".to_string(), "  ".to_string(), "discord://token@id".to_string()];
+        let urls = vec![
+            "".to_string(),
+            "  ".to_string(),
+            "discord://token@id".to_string(),
+        ];
         let notifier = ShoutrrrNotifier::new(&urls).unwrap();
         assert_eq!(notifier.urls.len(), 1);
     }
@@ -1316,7 +1335,10 @@ mod tests {
             ],
         };
         let desc = notifier.describe();
-        assert_eq!(desc, "Discord, Slack, Telegram, Gotify, Pushover, generic webhook, custom");
+        assert_eq!(
+            desc,
+            "Discord, Slack, Telegram, Gotify, Pushover, generic webhook, custom"
+        );
     }
 
     // ---- send_telegram, send_gotify, send_pushover with wiremock ----

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -24,6 +24,7 @@ pub const EMOJI_CONFIG: &str = "\u{2699}\u{FE0F}";
 
 const INDENT_PREFIX: &str = "   ";
 
+#[derive(Clone)]
 pub struct PP {
     pub verbosity: Verbosity,
     pub emoji: bool,

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 /// Run a single update cycle.
 pub async fn update_once(
     config: &AppConfig,
+    domains: HashMap<IpType, Vec<String>>,
     handle: &CloudflareHandle,
     notifier: &CompositeNotifier,
     heartbeat: &Heartbeat,
@@ -113,7 +114,7 @@ pub async fn update_once(
         }
 
         // Update DNS records (env var mode - domain-based)
-        for (ip_type, domains) in &config.domains {
+        for (ip_type, domains) in domains.iter() {
             let ips = detected_ips.get(ip_type).cloned().unwrap_or_default();
 
             if ips.is_empty() && !config.delete_on_failure {
@@ -722,6 +723,7 @@ mod tests {
             auth: Auth::Token("test-token".to_string()),
             providers,
             domains,
+            docker_host: None,
             waf_lists,
             update_cron: CronSchedule::Once,
             update_on_start: true,
@@ -863,7 +865,18 @@ mod tests {
         let ppfmt = pp();
 
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut HashSet::new(), &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut HashSet::new(),
+            &crate::test_client(),
+        )
+        .await;
         assert!(ok);
     }
 
@@ -916,12 +929,34 @@ mod tests {
         let mut noop_reported = HashSet::new();
 
         // First call: noop_reported is empty, so "up to date" is reported and key is inserted
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut noop_reported, &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut noop_reported,
+            &crate::test_client(),
+        )
+        .await;
         assert!(ok);
         assert!(noop_reported.contains("home.example.com:A"), "noop_reported should contain the domain key after first noop");
 
         // Second call: noop_reported already has the key, so the message is suppressed
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut noop_reported, &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut noop_reported,
+            &crate::test_client(),
+        )
+        .await;
         assert!(ok);
         assert_eq!(noop_reported.len(), 1, "noop_reported should still have exactly one entry");
     }
@@ -994,7 +1029,18 @@ mod tests {
         noop_reported.insert("home.example.com:A".to_string());
 
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut noop_reported, &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut noop_reported,
+            &crate::test_client(),
+        )
+        .await;
         assert!(ok);
         assert!(!noop_reported.contains("home.example.com:A"), "noop_reported should be cleared after an update");
     }
@@ -1040,7 +1086,18 @@ mod tests {
 
         // all_ok = true because no zone-level errors occurred (empty ips just noop or warn)
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut HashSet::new(), &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut HashSet::new(),
+            &crate::test_client(),
+        )
+        .await;
         // Providers with None are not inserted in loop, so no IP detection warning is emitted,
         // no detected_ips entry is created, and set_ips is called with empty slice -> Noop.
         assert!(ok);
@@ -1090,7 +1147,18 @@ mod tests {
         let ppfmt = pp();
 
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut HashSet::new(), &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut HashSet::new(),
+            &crate::test_client(),
+        )
+        .await;
         assert!(!ok, "Expected false when zone is not found");
     }
 
@@ -1140,7 +1208,18 @@ mod tests {
 
         // dry_run returns Updated from set_ips (it signals intent), all_ok should be true
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut HashSet::new(), &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut HashSet::new(),
+            &crate::test_client(),
+        )
+        .await;
         assert!(ok);
     }
 
@@ -1206,7 +1285,18 @@ mod tests {
         let ppfmt = pp();
 
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut HashSet::new(), &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut HashSet::new(),
+            &crate::test_client(),
+        )
+        .await;
         assert!(ok);
     }
 
@@ -1260,7 +1350,18 @@ mod tests {
         let ppfmt = pp();
 
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut HashSet::new(), &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut HashSet::new(),
+            &crate::test_client(),
+        )
+        .await;
         assert!(ok);
     }
 
@@ -1300,7 +1401,18 @@ mod tests {
         let ppfmt = pp();
 
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut HashSet::new(), &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut HashSet::new(),
+            &crate::test_client(),
+        )
+        .await;
         assert!(!ok, "Expected false when WAF list is not found");
     }
 
@@ -1385,7 +1497,18 @@ mod tests {
         let ppfmt = pp();
 
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut HashSet::new(), &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut HashSet::new(),
+            &crate::test_client(),
+        )
+        .await;
         assert!(ok);
     }
 
@@ -1402,7 +1525,18 @@ mod tests {
         let ppfmt = pp();
 
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut HashSet::new(), &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut HashSet::new(),
+            &crate::test_client(),
+        )
+        .await;
         assert!(ok);
     }
 
@@ -1787,7 +1921,18 @@ mod tests {
 
         // set_ips with empty ips and no existing records = Noop; all_ok = true
         let mut cf_cache = CachedCloudflareFilter::new();
-        let ok = update_once(&config, &cf, &notifier, &heartbeat, &mut cf_cache, &ppfmt, &mut HashSet::new(), &crate::test_client()).await;
+        let ok = update_once(
+            &config,
+            config.domains.clone(),
+            &cf,
+            &notifier,
+            &heartbeat,
+            &mut cf_cache,
+            &ppfmt,
+            &mut HashSet::new(),
+            &crate::test_client(),
+        )
+        .await;
         assert!(ok);
     }
     // -------------------------------------------------------
@@ -2386,6 +2531,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
+            config.domains.clone(),
             &cf,
             &notifier,
             &heartbeat,
@@ -2459,6 +2605,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
+            config.domains.clone(),
             &cf,
             &notifier,
             &heartbeat,
@@ -2498,6 +2645,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
+            config.domains.clone(),
             &cf,
             &notifier,
             &heartbeat,
@@ -2576,6 +2724,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
+            config.domains.clone(),
             &cf,
             &notifier,
             &heartbeat,

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 /// Run a single update cycle.
 pub async fn update_once(
     config: &AppConfig,
-    domains: HashMap<IpType, Vec<String>>,
+    domains: &HashMap<IpType, Vec<String>>,
     handle: &CloudflareHandle,
     notifier: &CompositeNotifier,
     heartbeat: &Heartbeat,
@@ -71,8 +71,9 @@ pub async fn update_once(
 
         // Filter out Cloudflare IPs if enabled
         if config.reject_cloudflare_ips {
-            if let Some(cf_filter) =
-                cf_cache.get(&detection_client, config.detection_timeout, ppfmt).await
+            if let Some(cf_filter) = cf_cache
+                .get(&detection_client, config.detection_timeout, ppfmt)
+                .await
             {
                 for (ip_type, ips) in detected_ips.iter_mut() {
                     let before_count = ips.len();
@@ -183,13 +184,14 @@ pub async fn update_once(
                         noop_reported.remove(&noop_key);
                         notify = true;
                         all_ok = false;
-                        messages.push(Message::new_fail(&format!(
-                            "Failed to update {domain_str}"
-                        )));
+                        messages.push(Message::new_fail(&format!("Failed to update {domain_str}")));
                     }
                     SetResult::Noop => {
                         if noop_reported.insert(noop_key) {
-                            ppfmt.infof(pp::EMOJI_SKIP, &format!("Record {domain_str} is up to date"));
+                            ppfmt.infof(
+                                pp::EMOJI_SKIP,
+                                &format!("Record {domain_str} is up to date"),
+                            );
                         }
                     }
                 }
@@ -199,11 +201,7 @@ pub async fn update_once(
         // Update WAF lists
         for waf_list in &config.waf_lists {
             // Collect all detected IPs for WAF lists
-            let all_ips: Vec<IpAddr> = detected_ips
-                .values()
-                .flatten()
-                .copied()
-                .collect();
+            let all_ips: Vec<IpAddr> = detected_ips.values().flatten().copied().collect();
 
             let result = handle
                 .set_waf_list(
@@ -237,7 +235,10 @@ pub async fn update_once(
                 }
                 SetResult::Noop => {
                     if noop_reported.insert(noop_key) {
-                        ppfmt.infof(pp::EMOJI_SKIP, &format!("WAF list {} is up to date", waf_list.describe()));
+                        ppfmt.infof(
+                            pp::EMOJI_SKIP,
+                            &format!("WAF list {} is up to date", waf_list.describe()),
+                        );
                     }
                 }
             }
@@ -326,8 +327,9 @@ async fn update_legacy(
     // Filter out Cloudflare IPs if enabled
     if config.reject_cloudflare_ips {
         let before_count = ips.len();
-        if let Some(cf_filter) =
-            cf_cache.get(&detection_client, config.detection_timeout, ppfmt).await
+        if let Some(cf_filter) = cf_cache
+            .get(&detection_client, config.detection_timeout, ppfmt)
+            .await
         {
             ips.retain(|key, ip_info| {
                 if let Ok(addr) = ip_info.ip.parse::<std::net::IpAddr>() {
@@ -388,8 +390,12 @@ pub async fn final_delete(
 
         for domain_str in domains {
             if let Some(zone_id) = handle.zone_id_of_domain(domain_str, ppfmt).await {
-                handle.final_delete(&zone_id, domain_str, record_type, ppfmt).await;
-                messages.push(Message::new_ok(&format!("Deleted records for {domain_str}")));
+                handle
+                    .final_delete(&zone_id, domain_str, record_type, ppfmt)
+                    .await;
+                messages.push(Message::new_ok(&format!(
+                    "Deleted records for {domain_str}"
+                )));
             }
         }
     }
@@ -484,9 +490,9 @@ impl LegacyDdnsClient {
                 "zones/{}/dns_records?per_page=100&type={record_type}",
                 entry.zone_id
             );
-            let answer: Option<LegacyCfResponse<Vec<LegacyDnsRecord>>> =
-                self.cf_api(&endpoint, "GET", entry, None::<&()>.as_ref())
-                    .await;
+            let answer: Option<LegacyCfResponse<Vec<LegacyDnsRecord>>> = self
+                .cf_api(&endpoint, "GET", entry, None::<&()>.as_ref())
+                .await;
 
             if let Some(resp) = answer {
                 if let Some(records) = resp.result {
@@ -495,10 +501,8 @@ impl LegacyDdnsClient {
                             println!("[DRY RUN] Would delete stale record {}", record.id);
                             continue;
                         }
-                        let del_endpoint = format!(
-                            "zones/{}/dns_records/{}",
-                            entry.zone_id, record.id
-                        );
+                        let del_endpoint =
+                            format!("zones/{}/dns_records/{}", entry.zone_id, record.id);
                         let _: Option<serde_json::Value> = self
                             .cf_api(&del_endpoint, "DELETE", entry, None::<&()>.as_ref())
                             .await;
@@ -585,9 +589,9 @@ impl LegacyDdnsClient {
                     "zones/{}/dns_records?per_page=100&type={}",
                     entry.zone_id, ip.record_type
                 );
-                let dns_records: Option<LegacyCfResponse<Vec<LegacyDnsRecord>>> =
-                    self.cf_api(&dns_endpoint, "GET", entry, None::<&()>.as_ref())
-                        .await;
+                let dns_records: Option<LegacyCfResponse<Vec<LegacyDnsRecord>>> = self
+                    .cf_api(&dns_endpoint, "GET", entry, None::<&()>.as_ref())
+                    .await;
 
                 let mut identifier: Option<String> = None;
                 let mut modified = false;
@@ -606,9 +610,7 @@ impl LegacyDdnsClient {
                                     }
                                 } else {
                                     identifier = Some(r.id.clone());
-                                    if r.content != record.content
-                                        || r.proxied != record.proxied
-                                    {
+                                    if r.content != record.content || r.proxied != record.proxied {
                                         modified = true;
                                     }
                                 }
@@ -632,10 +634,7 @@ impl LegacyDdnsClient {
                                 .cf_api(&update_endpoint, "PUT", entry, Some(&record))
                                 .await;
                         }
-                        messages.push(Message::new_ok(&format!(
-                            "Updated {fqdn} -> {}",
-                            ip.ip
-                        )));
+                        messages.push(Message::new_ok(&format!("Updated {fqdn} -> {}", ip.ip)));
                     } else if noop_reported.insert(noop_key) {
                         if self.dry_run {
                             println!("[DRY RUN] Record {fqdn} is up to date");
@@ -655,10 +654,7 @@ impl LegacyDdnsClient {
                             .cf_api(&create_endpoint, "POST", entry, Some(&record))
                             .await;
                     }
-                    messages.push(Message::new_ok(&format!(
-                        "Created {fqdn} -> {}",
-                        ip.ip
-                    )));
+                    messages.push(Message::new_ok(&format!("Created {fqdn} -> {}", ip.ip)));
                 }
 
                 if purge_unknown_records {
@@ -684,7 +680,7 @@ impl LegacyDdnsClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cloudflare::{Auth, CloudflareHandle, TTL, WAFList};
+    use crate::cloudflare::{Auth, CloudflareHandle, WAFList, TTL};
     use crate::config::{AppConfig, CronSchedule};
     use crate::notifier::{CompositeNotifier, Heartbeat};
     use crate::pp::PP;
@@ -842,8 +838,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path(format!("/zones/{zone_id}/dns_records")))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(dns_record_created("rec-1", domain, ip)),
+                ResponseTemplate::new(200).set_body_json(dns_record_created("rec-1", domain, ip)),
             )
             .mount(&server)
             .await;
@@ -867,7 +862,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -903,8 +898,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path_regex(format!("/zones/{zone_id}/dns_records")))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(dns_records_one("rec-1", domain, ip)),
+                ResponseTemplate::new(200).set_body_json(dns_records_one("rec-1", domain, ip)),
             )
             .mount(&server)
             .await;
@@ -931,7 +925,7 @@ mod tests {
         // First call: noop_reported is empty, so "up to date" is reported and key is inserted
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -942,12 +936,15 @@ mod tests {
         )
         .await;
         assert!(ok);
-        assert!(noop_reported.contains("home.example.com:A"), "noop_reported should contain the domain key after first noop");
+        assert!(
+            noop_reported.contains("home.example.com:A"),
+            "noop_reported should contain the domain key after first noop"
+        );
 
         // Second call: noop_reported already has the key, so the message is suppressed
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -958,7 +955,11 @@ mod tests {
         )
         .await;
         assert!(ok);
-        assert_eq!(noop_reported.len(), 1, "noop_reported should still have exactly one entry");
+        assert_eq!(
+            noop_reported.len(),
+            1,
+            "noop_reported should still have exactly one entry"
+        );
     }
 
     /// noop_reported is cleared when a record is updated, so "up to date" prints again
@@ -985,8 +986,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path_regex(format!("/zones/{zone_id}/dns_records")))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(dns_records_one("rec-1", domain, old_ip)),
+                ResponseTemplate::new(200).set_body_json(dns_records_one("rec-1", domain, old_ip)),
             )
             .mount(&server)
             .await;
@@ -1004,7 +1004,9 @@ mod tests {
         // Delete stale record
         Mock::given(method("DELETE"))
             .and(path(format!("/zones/{zone_id}/dns_records/rec-1")))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": {}})))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": {}})),
+            )
             .mount(&server)
             .await;
 
@@ -1031,7 +1033,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -1042,7 +1044,10 @@ mod tests {
         )
         .await;
         assert!(ok);
-        assert!(!noop_reported.contains("home.example.com:A"), "noop_reported should be cleared after an update");
+        assert!(
+            !noop_reported.contains("home.example.com:A"),
+            "noop_reported should be cleared after an update"
+        );
     }
 
     /// update_once returns true even when IP detection yields empty (no providers configured),
@@ -1088,7 +1093,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -1114,9 +1119,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/zones"))
             .and(query_param("name", domain))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(zones_empty_response()),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(zones_empty_response()))
             .mount(&server)
             .await;
 
@@ -1124,9 +1127,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/zones"))
             .and(query_param("name", "example.com"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(zones_empty_response()),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(zones_empty_response()))
             .mount(&server)
             .await;
 
@@ -1149,7 +1150,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -1210,7 +1211,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -1236,8 +1237,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path(format!("/accounts/{account_id}/rules/lists")))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(waf_lists_response(list_id, list_name)),
+                ResponseTemplate::new(200).set_body_json(waf_lists_response(list_id, list_name)),
             )
             .mount(&server)
             .await;
@@ -1248,8 +1248,7 @@ mod tests {
                 "/accounts/{account_id}/rules/lists/{list_id}/items"
             )))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(waf_items_response(serde_json::json!([]))),
+                ResponseTemplate::new(200).set_body_json(waf_items_response(serde_json::json!([]))),
             )
             .mount(&server)
             .await;
@@ -1287,7 +1286,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -1312,8 +1311,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path(format!("/accounts/{account_id}/rules/lists")))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(waf_lists_response(list_id, list_name)),
+                ResponseTemplate::new(200).set_body_json(waf_lists_response(list_id, list_name)),
             )
             .mount(&server)
             .await;
@@ -1323,8 +1321,7 @@ mod tests {
                 "/accounts/{account_id}/rules/lists/{list_id}/items"
             )))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(waf_items_response(serde_json::json!([]))),
+                ResponseTemplate::new(200).set_body_json(waf_items_response(serde_json::json!([]))),
             )
             .mount(&server)
             .await;
@@ -1343,7 +1340,12 @@ mod tests {
             list_name: list_name.to_string(),
         };
 
-        let config = make_config(providers, HashMap::new(), vec![waf_list], true /* dry_run */);
+        let config = make_config(
+            providers,
+            HashMap::new(),
+            vec![waf_list],
+            true, /* dry_run */
+        );
         let cf = handle(&server.uri());
         let notifier = empty_notifier();
         let heartbeat = empty_heartbeat();
@@ -1352,7 +1354,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -1403,7 +1405,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -1499,7 +1501,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -1527,7 +1529,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -1567,8 +1569,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path_regex(format!("/zones/{zone_id}/dns_records")))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(dns_records_one(record_id, domain, ip)),
+                ResponseTemplate::new(200).set_body_json(dns_records_one(record_id, domain, ip)),
             )
             .mount(&server)
             .await;
@@ -1644,18 +1645,14 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/zones"))
             .and(query_param("name", domain))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(zones_empty_response()),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(zones_empty_response()))
             .mount(&server)
             .await;
 
         Mock::given(method("GET"))
             .and(path("/zones"))
             .and(query_param("name", "example.com"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(zones_empty_response()),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(zones_empty_response()))
             .mount(&server)
             .await;
 
@@ -1686,8 +1683,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path(format!("/accounts/{account_id}/rules/lists")))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(waf_lists_response(list_id, list_name)),
+                ResponseTemplate::new(200).set_body_json(waf_lists_response(list_id, list_name)),
             )
             .mount(&server)
             .await;
@@ -1697,11 +1693,11 @@ mod tests {
             .and(path(format!(
                 "/accounts/{account_id}/rules/lists/{list_id}/items"
             )))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(waf_items_response(serde_json::json!([
+            .respond_with(ResponseTemplate::new(200).set_body_json(waf_items_response(
+                serde_json::json!([
                     { "id": item_id, "ip": ip, "comment": null }
-                ]))),
-            )
+                ]),
+            )))
             .mount(&server)
             .await;
 
@@ -1742,8 +1738,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path(format!("/accounts/{account_id}/rules/lists")))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(waf_lists_response(list_id, list_name)),
+                ResponseTemplate::new(200).set_body_json(waf_lists_response(list_id, list_name)),
             )
             .mount(&server)
             .await;
@@ -1754,8 +1749,7 @@ mod tests {
                 "/accounts/{account_id}/rules/lists/{list_id}/items"
             )))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(waf_items_response(serde_json::json!([]))),
+                ResponseTemplate::new(200).set_body_json(waf_items_response(serde_json::json!([]))),
             )
             .mount(&server)
             .await;
@@ -1803,8 +1797,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path_regex(format!("/zones/{zone_id}/dns_records")))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(dns_records_one(record_id, domain, ip)),
+                ResponseTemplate::new(200).set_body_json(dns_records_one(record_id, domain, ip)),
             )
             .mount(&server)
             .await;
@@ -1823,8 +1816,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path(format!("/accounts/{account_id}/rules/lists")))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(waf_lists_response(list_id, list_name)),
+                ResponseTemplate::new(200).set_body_json(waf_lists_response(list_id, list_name)),
             )
             .mount(&server)
             .await;
@@ -1834,11 +1826,11 @@ mod tests {
             .and(path(format!(
                 "/accounts/{account_id}/rules/lists/{list_id}/items"
             )))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(waf_items_response(serde_json::json!([
+            .respond_with(ResponseTemplate::new(200).set_body_json(waf_items_response(
+                serde_json::json!([
                     { "id": item_id, "ip": ip, "comment": null }
-                ]))),
-            )
+                ]),
+            )))
             .mount(&server)
             .await;
 
@@ -1923,7 +1915,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -2137,7 +2129,8 @@ mod tests {
             subdomains: vec![LegacySubdomainEntry::Simple("@".to_string())],
             proxied: false,
         }];
-        ddns.commit_record(&ip, &config, 300, false, &mut HashSet::new()).await;
+        ddns.commit_record(&ip, &config, 300, false, &mut HashSet::new())
+            .await;
     }
 
     #[tokio::test]
@@ -2193,7 +2186,8 @@ mod tests {
             subdomains: vec![LegacySubdomainEntry::Simple("@".to_string())],
             proxied: false,
         }];
-        ddns.commit_record(&ip, &config, 300, false, &mut HashSet::new()).await;
+        ddns.commit_record(&ip, &config, 300, false, &mut HashSet::new())
+            .await;
     }
 
     #[tokio::test]
@@ -2236,7 +2230,8 @@ mod tests {
             proxied: false,
         }];
         // Should not POST
-        ddns.commit_record(&ip, &config, 300, false, &mut HashSet::new()).await;
+        ddns.commit_record(&ip, &config, 300, false, &mut HashSet::new())
+            .await;
     }
 
     #[tokio::test]
@@ -2289,7 +2284,8 @@ mod tests {
             }],
             proxied: false,
         }];
-        ddns.commit_record(&ip, &config, 300, false, &mut HashSet::new()).await;
+        ddns.commit_record(&ip, &config, 300, false, &mut HashSet::new())
+            .await;
     }
 
     #[tokio::test]
@@ -2341,7 +2337,8 @@ mod tests {
             subdomains: vec![LegacySubdomainEntry::Simple("@".to_string())],
             proxied: false,
         }];
-        ddns.commit_record(&ip, &config, 300, true, &mut HashSet::new()).await;
+        ddns.commit_record(&ip, &config, 300, true, &mut HashSet::new())
+            .await;
     }
 
     #[tokio::test]
@@ -2378,10 +2375,13 @@ mod tests {
             dry_run: false,
         };
         let mut ips = HashMap::new();
-        ips.insert("ipv4".to_string(), LegacyIpInfo {
-            record_type: "A".to_string(),
-            ip: "198.51.100.1".to_string(),
-        });
+        ips.insert(
+            "ipv4".to_string(),
+            LegacyIpInfo {
+                record_type: "A".to_string(),
+                ip: "198.51.100.1".to_string(),
+            },
+        );
         let config = vec![crate::config::LegacyCloudflareEntry {
             authentication: crate::config::LegacyAuthentication {
                 api_token: "test-token".to_string(),
@@ -2391,7 +2391,8 @@ mod tests {
             subdomains: vec![LegacySubdomainEntry::Simple("@".to_string())],
             proxied: false,
         }];
-        ddns.update_ips(&ips, &config, 300, false, &mut HashSet::new()).await;
+        ddns.update_ips(&ips, &config, 300, false, &mut HashSet::new())
+            .await;
     }
 
     #[tokio::test]
@@ -2531,7 +2532,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -2605,7 +2606,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -2645,7 +2646,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,
@@ -2724,7 +2725,7 @@ mod tests {
         let mut cf_cache = CachedCloudflareFilter::new();
         let ok = update_once(
             &config,
-            config.domains.clone(),
+            &config.domains,
             &cf,
             &notifier,
             &heartbeat,


### PR DESCRIPTION
Hello,

Using ddns with docker most of the time. And it is annoying to update env vars when adding new local domains. So I made use of `/var/run/docker.sock`. And now it is possible to use ddns like this. 

```yaml
  ddns:
    image: timothyjmiller/cloudflare-ddns:latest
    restart: unless-stopped
    network_mode: host
    environment:
      - DOCKER_HOST=unix:///var/run/docker.sock
    volumes:
      - "/var/run/docker.sock:/var/run/docker.sock:ro"

  api:
    image: "..."
    labels:
      - "ddns.domain=api-local.example.com"
      - "traefik.enable=true"
      - "traefik.http.routers.api.rule=Host(`api-local.example.com`)"
```

